### PR TITLE
Rewrite API

### DIFF
--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -1,5 +1,6 @@
 package io.github.prospector.modmenu;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.github.prospector.modmenu.api.ModMenuApi;
@@ -7,20 +8,45 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.minecraft.client.gui.Screen;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 public class ModMenu implements ClientModInitializer {
 	public static final String MOD_ID = "modmenu";
 	public static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().create();
 
-	public static final Map<String, Runnable> CONFIG_OVERRIDES_LEGACY = new HashMap<>();
-	public static final Map<String, ModMenuApi> API_MAP = new HashMap<>();
+	private static final Map<String, Runnable> LEGACY_CONFIG_SCREEN_TASKS = new HashMap<>();
 	public static final Map<String, Boolean> MOD_API = new HashMap<>();
 	public static final Map<String, Boolean> MOD_CLIENTSIDE = new HashMap<>();
 
 	public static boolean noFabric;
+
+	private static ImmutableMap<String, Function<Screen, Screen>> configScreenFactories = ImmutableMap.of();
+
+	public static boolean hasFactory(String modid) {
+		return configScreenFactories.containsKey(modid);
+	}
+
+	public static Screen getConfigScreen(String modid, Screen menuScreen) {
+		Function<Screen, Screen> factory = configScreenFactories.get(modid);
+		return factory != null ? factory.apply(menuScreen) : null;
+	}
+
+	public static void openConfigScreen(String modid) {
+		Runnable opener = LEGACY_CONFIG_SCREEN_TASKS.get(modid);
+		if (opener != null) opener.run();
+	}
+
+	public static void addLegacyConfigScreenTask(String modid, Runnable task) {
+		LEGACY_CONFIG_SCREEN_TASKS.putIfAbsent(modid, task);
+	}
+	
+	public static boolean hasLegacyConfigScreenTask(String modid) {
+		return LEGACY_CONFIG_SCREEN_TASKS.containsKey(modid);
+	}
 
 	public static void updateCacheApiValue(String modid, boolean value) {
 		MOD_API.put(modid, value);
@@ -33,7 +59,9 @@ public class ModMenu implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		noFabric = !FabricLoader.getInstance().isModLoaded("fabric");
-		FabricLoader.getInstance().getEntrypoints("modmenu", ModMenuApi.class).forEach(modMenuApi -> API_MAP.put(modMenuApi.getModId(), modMenuApi));
+		ImmutableMap.Builder<String, Function<Screen, Screen>> factories = ImmutableMap.builder();
+		FabricLoader.getInstance().getEntrypoints("modmenu", ModMenuApi.class).forEach(api -> factories.put(api.getModId(), api.getConfigScreenFactory()));
+		configScreenFactories = factories.build();
 		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
 			ModMetadata metadata = mod.getMetadata();
 			try {

--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -24,14 +24,14 @@ public class ModMenu implements ClientModInitializer {
 
 	public static boolean noFabric;
 
-	private static ImmutableMap<String, Function<Screen, Screen>> configScreenFactories = ImmutableMap.of();
+	private static ImmutableMap<String, Function<Screen, ? extends Screen>> configScreenFactories = ImmutableMap.of();
 
 	public static boolean hasFactory(String modid) {
 		return configScreenFactories.containsKey(modid);
 	}
 
 	public static Screen getConfigScreen(String modid, Screen menuScreen) {
-		Function<Screen, Screen> factory = configScreenFactories.get(modid);
+		Function<Screen, ? extends Screen> factory = configScreenFactories.get(modid);
 		return factory != null ? factory.apply(menuScreen) : null;
 	}
 
@@ -59,7 +59,7 @@ public class ModMenu implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		noFabric = !FabricLoader.getInstance().isModLoaded("fabric");
-		ImmutableMap.Builder<String, Function<Screen, Screen>> factories = ImmutableMap.builder();
+		ImmutableMap.Builder<String, Function<Screen, ? extends Screen>> factories = ImmutableMap.builder();
 		FabricLoader.getInstance().getEntrypoints("modmenu", ModMenuApi.class).forEach(api -> factories.put(api.getModId(), api.getConfigScreenFactory()));
 		configScreenFactories = factories.build();
 		for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {

--- a/src/main/java/io/github/prospector/modmenu/api/ModMenuApi.java
+++ b/src/main/java/io/github/prospector/modmenu/api/ModMenuApi.java
@@ -46,7 +46,7 @@ public interface ModMenuApi {
 	 *
 	 * @return A factory function for constructing config screen instances.
 	 */
-	default Function<Screen, Screen> getConfigScreenFactory() {
+	default Function<Screen, ? extends Screen> getConfigScreenFactory() {
 		return screen -> getConfigScreen(screen).map(Supplier::get).orElse(null);
 	}
 }

--- a/src/main/java/io/github/prospector/modmenu/api/ModMenuApi.java
+++ b/src/main/java/io/github/prospector/modmenu/api/ModMenuApi.java
@@ -4,21 +4,49 @@ import io.github.prospector.modmenu.ModMenu;
 import net.minecraft.client.gui.Screen;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface ModMenuApi {
-
-	/* Please use the new API by making a class that implements ModMenuApi and add it as a "modmenu" entry point
-	 * This method will probably go away come the 1.15 snapshots
-	 * */
+	/**
+	 * Replaced with {@link ModMenuApi#getConfigScreen(Screen)}, with
+	 * the ModMenuApi implemented onto a class that is added as an
+	 * entry point to your fabric mod metadata.
+	 *
+	 * @deprecated Will be removed in 1.15 snapshots.
+	 */
 	@Deprecated
 	static void addConfigOverride(String modid, Runnable action) {
-		ModMenu.CONFIG_OVERRIDES_LEGACY.put(modid, action);
+		ModMenu.addLegacyConfigScreenTask(modid, action);
 	}
 
+	/**
+	 * Used to determine the owner of this API implementation.
+	 * Will be deprecated and removed once Fabric has support
+	 * for providing ownership information about entry points.
+	 */
 	String getModId();
 
+	/**
+	 * Replaced with {@link ModMenuApi#getConfigScreenFactory()}, which
+	 * now allows ModMenu to open the screen for you, rather than depending
+	 * on you to open it, and gets rid of the messy Optional->Supplier wrapping.
+	 *
+	 * @deprecated Will be removed in 1.15 snapshots.
+	 */
+	@Deprecated
 	default Optional<Supplier<Screen>> getConfigScreen(Screen screen) {
 		return Optional.empty();
+	}
+
+	/**
+	 * Used to construct a new config screen instance when your mod's
+	 * configuration button is selected on the mod menu screen. The
+	 * screen instance parameter is the active mod menu screen.
+	 *
+	 * @return A factory function for constructing config screen instances.
+	 */
+	default Function<Screen, Screen> getConfigScreenFactory() {
+		return screen -> getConfigScreen(screen).map(Supplier::get).orElse(null);
 	}
 }

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
@@ -9,7 +9,6 @@ import io.github.prospector.modmenu.util.BadgeRenderer;
 import io.github.prospector.modmenu.util.RenderUtils;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.metadata.ModMetadata;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.Screen;
 import net.minecraft.client.gui.ingame.ConfirmChatLinkScreen;
@@ -87,16 +86,17 @@ public class ModListScreen extends Screen {
 		this.descriptionListWidget = new DescriptionListWidget(this.minecraft, paneWidth, this.height, paneY + 60, this.height - 36, font.fontHeight + 1, this);
 		this.descriptionListWidget.setLeftPos(rightPaneX);
 		ButtonWidget configureButton = new TexturedButtonWidget(width - 24, paneY, 20, 20, 0, 0, CONFIGURE_BUTTON_LOCATION, 32, 64, button -> {
-			if (ModMenu.API_MAP.containsKey(modList.getSelected().metadata.getId()) && ModMenu.API_MAP.get(modList.getSelected().metadata.getId()).getConfigScreen(ModListScreen.this).isPresent()) {
-				MinecraftClient.getInstance().openScreen(ModMenu.API_MAP.get(modList.getSelected().metadata.getId()).getConfigScreen(this).get().get());
+			final Screen screen = ModMenu.getConfigScreen(modList.getSelected().metadata.getId(), this);
+			if (screen != null) {
+				minecraft.openScreen(screen);
 			} else {
-				ModMenu.CONFIG_OVERRIDES_LEGACY.get(modList.getSelected().metadata.getId()).run();
+				ModMenu.openConfigScreen(modList.getSelected().metadata.getId());
 			}
 		},
 			ModMenu.noFabric ? "Configure..." : I18n.translate("modmenu.configure")) {
 			@Override
 			public void render(int var1, int var2, float var3) {
-				active = modList.getSelected() != null && ModMenu.API_MAP.containsKey(modList.getSelected().metadata.getId()) && ModMenu.API_MAP.get(modList.getSelected().metadata.getId()).getConfigScreen(ModListScreen.this).isPresent() || ModMenu.CONFIG_OVERRIDES_LEGACY.get(modList.getSelected().metadata.getId()) != null;
+				active = modList.getSelected() != null && ModMenu.hasFactory(modList.getSelected().metadata.getId()) || ModMenu.hasLegacyConfigScreenTask(modList.getSelected().metadata.getId());
 				visible = active;
 				super.render(var1, var2, var3);
 			}


### PR DESCRIPTION
Replaced the `Optional<Supplier<Screen>>` mess with a `Function<Screen, Screen>` factory which is cached on game initialization within `ModMenu#init`. The previous method has been deprecated, and the java docs have been updated to provide mod information about the API and its state.