### PR TITLE
Cache mod icons to fix GUI freezes

### DIFF
--- a/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
@@ -21,11 +21,16 @@ import org.apache.logging.log4j.Logger;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEntry> implements AutoCloseable {
 	public static final Identifier UNKNOWN_ICON = new Identifier("textures/misc/unknown_pack.png");
 	private static final Logger LOGGER = LogManager.getLogger();
+
+	private static final Map<Identifier, NativeImageBackedTexture> MOD_ICONS = new HashMap<>();
+
 	protected final MinecraftClient client;
 	protected final ModContainer container;
 	protected final ModMetadata metadata;
@@ -39,7 +44,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		this.metadata = container.getMetadata();
 		this.client = MinecraftClient.getInstance();
 		this.iconLocation = new Identifier("modmenu", metadata.getId() + "_icon");
-		this.icon = this.createIcon();
+		this.icon = MOD_ICONS.computeIfAbsent(this.iconLocation, (id) -> this.createIcon());
 	}
 
 	@Override

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
@@ -32,19 +32,13 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 	protected final ModContainer container;
 	protected final ModMetadata metadata;
 	protected final ModListWidget list;
-	protected final Identifier iconLocation;
-	protected final NativeImageBackedTexture icon;
+	protected Identifier iconLocation;
 
 	public ModListEntry(ModContainer container, ModListWidget list) {
 		this.container = container;
 		this.list = list;
 		this.metadata = container.getMetadata();
 		this.client = MinecraftClient.getInstance();
-		this.iconLocation = new Identifier("modmenu", metadata.getId() + "_icon");
-		this.icon = this.createIcon();
-		if (this.icon != null) {
-			this.client.getTextureManager().registerTexture(this.iconLocation, this.icon);
-		}
 	}
 
 	@Override
@@ -52,7 +46,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		x += getXOffset();
 		rowWidth -= getXOffset();
 		GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-		this.client.getTextureManager().bindTexture(this.icon != null ? this.iconLocation : UNKNOWN_ICON);
+		this.bindIconTexture();
 		GlStateManager.enableBlend();
 		DrawableHelper.blit(x, y, 0.0F, 0.0F, 32, 32, 32, 32);
 		GlStateManager.disableBlend();
@@ -116,12 +110,17 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		return metadata;
 	}
 
-	public Identifier getIconLocation() {
-		return iconLocation;
-	}
-
-	public NativeImageBackedTexture getIcon() {
-		return icon;
+	public void bindIconTexture() {
+		if (this.iconLocation == null) {
+			this.iconLocation = new Identifier("modmenu", metadata.getId() + "_icon");
+			NativeImageBackedTexture icon = this.createIcon();
+			if (icon != null) {
+				this.client.getTextureManager().registerTexture(this.iconLocation, icon);
+			} else {
+				this.iconLocation = UNKNOWN_ICON;
+			}
+		}
+		this.client.getTextureManager().bindTexture(this.iconLocation);
 	}
 
 	public int getXOffset() {

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListEntry.java
@@ -5,6 +5,7 @@ import io.github.prospector.modmenu.ModMenu;
 import io.github.prospector.modmenu.util.BadgeRenderer;
 import io.github.prospector.modmenu.util.FabricHardcodedBsUtil;
 import io.github.prospector.modmenu.util.RenderUtils;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.minecraft.client.MinecraftClient;
@@ -20,16 +21,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.file.Path;
 import java.util.Objects;
 
-public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEntry> implements AutoCloseable {
+public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEntry> {
 	public static final Identifier UNKNOWN_ICON = new Identifier("textures/misc/unknown_pack.png");
 	private static final Logger LOGGER = LogManager.getLogger();
-
-	private static final Map<Identifier, NativeImageBackedTexture> MOD_ICONS = new HashMap<>();
 
 	protected final MinecraftClient client;
 	protected final ModContainer container;
@@ -44,7 +41,10 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		this.metadata = container.getMetadata();
 		this.client = MinecraftClient.getInstance();
 		this.iconLocation = new Identifier("modmenu", metadata.getId() + "_icon");
-		this.icon = MOD_ICONS.computeIfAbsent(this.iconLocation, (id) -> this.createIcon());
+		this.icon = this.createIcon();
+		if (this.icon != null) {
+			this.client.getTextureManager().registerTexture(this.iconLocation, this.icon);
+		}
 	}
 
 	@Override
@@ -75,45 +75,33 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 
 	private NativeImageBackedTexture createIcon() {
 		try {
-			InputStream inputStream;
-			try {
-				inputStream = Files.newInputStream(container.getPath(metadata.getIconPath(64 * MinecraftClient.getInstance().options.guiScale).orElse("assets/" + metadata.getId() + "/icon.png")));
-			} catch (NoSuchFileException e) {
+			Path path = container.getPath(metadata.getIconPath(64 * MinecraftClient.getInstance().options.guiScale).orElse("assets/" + metadata.getId() + "/icon.png"));
+			NativeImageBackedTexture cached = this.list.getCachedModIcon(path);
+			if (cached != null) {
+				return cached;
+			}
+			if (!Files.exists(path)) {
+				ModContainer modMenu = FabricLoader.getInstance().getModContainer(ModMenu.MOD_ID).orElseThrow(IllegalAccessError::new);
 				if (FabricHardcodedBsUtil.getFabricMods().contains(metadata.getId())) {
-					inputStream = getClass().getClassLoader().getResourceAsStream("assets/" + ModMenu.MOD_ID + "/fabric_icon.png");
+					path = modMenu.getPath("assets/" + ModMenu.MOD_ID + "/fabric_icon.png");
 				} else {
-					inputStream = getClass().getClassLoader().getResourceAsStream("assets/" + ModMenu.MOD_ID + "/grey_fabric_icon.png");
+					path = modMenu.getPath("assets/" + ModMenu.MOD_ID + "/grey_fabric_icon.png");
 				}
 			}
-			Throwable var3 = null;
-			NativeImageBackedTexture var6;
-			try {
+			cached = this.list.getCachedModIcon(path);
+			if (cached != null) {
+				return cached;
+			}
+			try (InputStream inputStream = Files.newInputStream(path)) {
 				NativeImage image = NativeImage.read(Objects.requireNonNull(inputStream));
 				Validate.validState(image.getHeight() == image.getWidth(), "Must be square icon");
-				NativeImageBackedTexture var5 = new NativeImageBackedTexture(image);
-				this.client.getTextureManager().registerTexture(this.iconLocation, var5);
-				var6 = var5;
-			} catch (Throwable var16) {
-				var3 = var16;
-				throw var16;
-			} finally {
-				if (inputStream != null) {
-					if (var3 != null) {
-						try {
-							inputStream.close();
-						} catch (Throwable var15) {
-							var3.addSuppressed(var15);
-						}
-					} else {
-						inputStream.close();
-					}
-				}
-
+				NativeImageBackedTexture tex = new NativeImageBackedTexture(image);
+				this.list.cacheModIcon(path, tex);
+				return tex;
 			}
 
-			return var6;
-		} catch (Throwable var18) {
-			LOGGER.error("Invalid icon for mod {}", this.container.getMetadata().getName(), var18);
+		} catch (Throwable t) {
+			LOGGER.error("Invalid icon for mod {}", this.container.getMetadata().getName(), t);
 			return null;
 		}
 	}
@@ -122,13 +110,6 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 	public boolean mouseClicked(double v, double v1, int i) {
 		list.select(this);
 		return true;
-	}
-
-	@Override
-	public void close() {
-		if (this.icon != null) {
-			this.icon.close();
-		}
 	}
 
 	public ModMetadata getMetadata() {

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
@@ -247,7 +247,7 @@ public class ModListScreen extends Screen {
 			ModMetadata metadata = selectedEntry.getMetadata();
 			int x = rightPaneX;
 			GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-			Objects.requireNonNull(this.minecraft).getTextureManager().bindTexture(this.selected.getIcon() != null ? this.selected.getIconLocation() : ModListEntry.UNKNOWN_ICON);
+			this.selected.bindIconTexture();
 			GlStateManager.enableBlend();
 			blit(x, paneY, 0.0F, 0.0F, 32, 32, 32, 32);
 			GlStateManager.disableBlend();
@@ -265,7 +265,7 @@ public class ModListScreen extends Screen {
 				setTooltip(I18n.translate("modmenu.modIdToolTip", metadata.getId()));
 			}
 			if (init || badgeRenderer == null || badgeRenderer.getMetadata() != metadata) {
-				badgeRenderer = new BadgeRenderer(x + imageOffset + this.minecraft.textRenderer.getStringWidth(trimmedName) + 2, paneY, width - 28, selectedEntry.container, this);
+				badgeRenderer = new BadgeRenderer(x + imageOffset + Objects.requireNonNull(this.minecraft).textRenderer.getStringWidth(trimmedName) + 2, paneY, width - 28, selectedEntry.container, this);
 				init = false;
 			}
 			badgeRenderer.draw(mouseX, mouseY);

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
@@ -301,6 +301,12 @@ public class ModListScreen extends Screen {
 		tessellator.draw();
 	}
 
+	@Override
+	public void onClose() {
+		super.onClose();
+		this.modList.close();
+	}
+
 	public void setTooltip(String tooltip) {
 		this.tooltip = tooltip;
 	}

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListWidget.java
@@ -7,6 +7,7 @@ import io.github.prospector.modmenu.gui.entries.ChildEntry;
 import io.github.prospector.modmenu.gui.entries.IndependentEntry;
 import io.github.prospector.modmenu.gui.entries.ParentEntry;
 import io.github.prospector.modmenu.util.FabricHardcodedBsUtil;
+import io.github.prospector.modmenu.util.TestModContainer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
@@ -26,6 +27,7 @@ import java.util.function.Supplier;
 
 public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> {
 	private static final Logger LOGGER = LogManager.getLogger();
+	public static final boolean DEBUG = Boolean.getBoolean("modmenu.debug");
 	private final ModListScreen parent;
 	private List<ModContainer> modContainerList = null;
 	private Set<ModContainer> addedMods = new HashSet<>();
@@ -117,6 +119,10 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> {
 		this.clearEntries();
 		addedMods.clear();
 		Collection<ModContainer> mods = FabricLoader.getInstance().getAllMods();
+		if (DEBUG) {
+			mods = new ArrayList<>(mods);
+			mods.addAll(TestModContainer.getTestModContainers());
+		}
 		if (this.modContainerList == null || refresh) {
 			this.modContainerList = new ArrayList<>();
 			modContainerList.addAll(mods);

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListWidget.java
@@ -16,18 +16,22 @@ import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.texture.NativeImageBackedTexture;
 import net.minecraft.client.util.NarratorManager;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.math.MathHelper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
 
-public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> {
+public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> implements AutoCloseable {
 	private static final Logger LOGGER = LogManager.getLogger();
 	public static final boolean DEBUG = Boolean.getBoolean("modmenu.debug");
+
+	private final Map<Path, NativeImageBackedTexture> modIconsCache = new HashMap<>();
 	private final ModListScreen parent;
 	private List<ModContainer> modContainerList = null;
 	private Set<ModContainer> addedMods = new HashSet<>();
@@ -308,5 +312,20 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> {
 
 	public int getDisplayedCount() {
 		return children().size();
+	}
+
+	@Override
+	public void close() {
+		for (NativeImageBackedTexture tex : this.modIconsCache.values()) {
+			tex.close();
+		}
+	}
+
+	NativeImageBackedTexture getCachedModIcon(Path path) {
+		return this.modIconsCache.get(path);
+	}
+
+	void cacheModIcon(Path path, NativeImageBackedTexture tex) {
+		this.modIconsCache.put(path, tex);
 	}
 }

--- a/src/main/java/io/github/prospector/modmenu/util/TestModContainer.java
+++ b/src/main/java/io/github/prospector/modmenu/util/TestModContainer.java
@@ -1,0 +1,147 @@
+package io.github.prospector.modmenu.util;
+
+import com.google.gson.JsonElement;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.SemanticVersion;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.Person;
+import net.fabricmc.loader.util.version.VersionParsingException;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.nio.file.Path;
+import java.util.*;
+
+public class TestModContainer implements ModContainer {
+
+	public static final Random RAND = new Random();
+	private static Collection<ModContainer> testModContainers;
+
+	public static Collection<ModContainer> getTestModContainers() {
+		if (testModContainers == null) {
+			testModContainers = new ArrayList<>();
+			for (int i = 0; i < 500; i++) {
+				testModContainers.add(new TestModContainer());
+			}
+		}
+		return testModContainers;
+	}
+
+	private final ModMetadata metadata = new TestModMetadata();
+	private final Path rootPath = FabricLoader.getInstance().getModContainer("fabricloader").orElseThrow(IllegalStateException::new).getRootPath();
+
+	@Override
+	public ModMetadata getMetadata() {
+		return this.metadata;
+	}
+
+	@Override
+	public Path getRootPath() {
+		return this.rootPath;
+	}
+
+	public static class TestModMetadata implements ModMetadata {
+		private final String id;
+		private final String description;
+		private final Version version;
+
+		public TestModMetadata() {
+			super();
+			this.id = RandomStringUtils.randomAlphabetic(10, 50).toLowerCase(Locale.ROOT);
+			this.description = RandomStringUtils.randomAlphabetic(500);
+			try {
+				this.version = SemanticVersion.parse(String.format("%d.%d.%d+%s", RAND.nextInt(10), RAND.nextInt(50), RAND.nextInt(200), RandomStringUtils.randomAlphanumeric(2, 10)));
+			} catch (VersionParsingException e) {
+				throw new AssertionError("Generated version is not semantic", e);
+			}
+		}
+
+		@Override
+		public String getType() {
+			return "test";
+		}
+
+		@Override
+		public String getId() {
+			return this.id;
+		}
+
+		@Override
+		public Version getVersion() {
+			return this.version;
+		}
+
+		@Override
+		public Collection<ModDependency> getDepends() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Collection<ModDependency> getRecommends() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Collection<ModDependency> getSuggests() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Collection<ModDependency> getConflicts() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Collection<ModDependency> getBreaks() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String getName() {
+			return this.getId();
+		}
+
+		@Override
+		public String getDescription() {
+			return this.description;
+		}
+
+		@Override
+		public Collection<Person> getAuthors() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Collection<Person> getContributors() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public ContactInformation getContact() {
+			return ContactInformation.EMPTY;
+		}
+
+		@Override
+		public Collection<String> getLicense() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Optional<String> getIconPath(int size) {
+			return Optional.empty();
+		}
+
+		@Override
+		public boolean containsCustomElement(String key) {
+			return false;
+		}
+
+		@Override
+		public JsonElement getCustomElement(String key) {
+			return null;
+		}
+	}
+}

--- a/src/main/java/io/github/prospector/modmenu/util/TestModContainer.java
+++ b/src/main/java/io/github/prospector/modmenu/util/TestModContainer.java
@@ -23,7 +23,7 @@ public class TestModContainer implements ModContainer {
 	public static Collection<ModContainer> getTestModContainers() {
 		if (testModContainers == null) {
 			testModContainers = new ArrayList<>();
-			for (int i = 0; i < 500; i++) {
+			for (int i = 0; i < 1000; i++) {
 				testModContainers.add(new TestModContainer());
 			}
 		}


### PR DESCRIPTION
Turns out the performance issues of Mod Menu come from creating a new `NativeImageBackedTexture` for every mod, every time you do anything. So the problem is solved by not doing that. This also fixes a major memory leak, where mod icons would be recreated every time but never closed.

I also committed the dummy mod container generator I used, as it may be more useful than duplicating `this.addEntry(parent)` a thousand times whenever something needs to be tested.