### PR TITLE
Add Japanese translations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=1.7.7
+mod_version=1.7.8
 maven_group=io.github.prospector
 archive_name=modmenu
 

--- a/src/main/resources/assets/modmenu/lang/ja_jp.json
+++ b/src/main/resources/assets/modmenu/lang/ja_jp.json
@@ -1,0 +1,23 @@
+{
+  "modmenu.title": "モッド",
+  "modmenu.loaded": "(%s ロードされた)",
+  "modmenu.config": "設定を変更して",
+  "modmenu.modsFolder": "モッドフォルダーを開く",
+  "modmenu.configsFolder": "設定フォルダーを開く",
+  "modmenu.configure": "構成して",
+  "modmenu.modIdToolTip": "モッドID: %s",
+  "modmenu.website": "ウェブサイト",
+  "modmenu.issues": "課題トラッカー",
+  "modmenu.authorPrefix": "%s",
+  "modmenu.search": "モッドを検索して",
+  "modmenu.clientsideOnly": "クライアント",
+  "modmenu.library": "モッド効用",
+  "modmenu.toggleFilterOptions": "フィルターの設定を切り替えて",
+  "modmenu.showLibraries": "モッド効用: %s",
+  "modmenu.showLibraries.true": "表す",
+  "modmenu.showLibraries.false": "隠す",
+  "modmenu.showingMods": "%s モッドを表す",
+  "modmenu.sorting": "整理: %s",
+  "modmenu.sorting.ascending": "上行",
+  "modmenu.sorting.decending": "下行"
+}


### PR DESCRIPTION
Japanese is my second language, so these probably aren't perfect, but I've done the best I could. Some notes:

- "Mod" could be translated as 改造 "kaizou", but that's closer to "remodeling", so I felt it was clearer to leave it as a loanword.
- Bylines aren't a big thing in Japanese, so I couldn't find a good prefix for the author name. Leaving it raw should be understandable enough from context though, since that seems to be the standard.
- There isn't a good word for "library" in a programming sense, so I translated it as モッド効用 "mod kouyou", literally "mod utility".
- The sort orders are translated as "ascending" and "descending", since there isn't a good way to express the same idea as A-Z/Z-A in Japanese (multiple character systems and context-based pronunciation make sorting a huge issue in JP).

Let me know if there are any issues!