### PR TITLE
Add a setting to show actual mod count versus all mod count

### DIFF
--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -102,6 +102,8 @@ public class ModMenu implements ClientModInitializer {
 	}
 
 	public static String getFormattedModCount() {
-		return NumberFormat.getInstance().format(FabricLoader.getInstance().getAllMods().size());
+		Collection<ModContainer> modContainers = FabricLoader.getInstance().getAllMods();
+		int actualModCount = modContainers.size()-libraryCount-1;
+		return NumberFormat.getInstance().format(actualModCount).concat("/")+NumberFormat.getInstance().format(modContainers.size());
 	}
 }

--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -5,7 +5,6 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.sun.org.apache.xpath.internal.operations.Mod;
 import io.github.prospector.modmenu.api.ModMenuApi;
 import io.github.prospector.modmenu.config.ModMenuConfig;
 import io.github.prospector.modmenu.config.ModMenuConfigManager;

--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -5,7 +5,9 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.sun.org.apache.xpath.internal.operations.Mod;
 import io.github.prospector.modmenu.api.ModMenuApi;
+import io.github.prospector.modmenu.config.ModMenuConfig;
 import io.github.prospector.modmenu.config.ModMenuConfigManager;
 import io.github.prospector.modmenu.util.HardcodedUtil;
 import net.fabricmc.api.ClientModInitializer;
@@ -103,7 +105,13 @@ public class ModMenu implements ClientModInitializer {
 
 	public static String getFormattedModCount() {
 		Collection<ModContainer> modContainers = FabricLoader.getInstance().getAllMods();
-		int actualModCount = modContainers.size()-libraryCount-1;
-		return NumberFormat.getInstance().format(actualModCount).concat("/")+NumberFormat.getInstance().format(modContainers.size());
+		if(ModMenuConfigManager.getConfig().showActualModCount())
+		{
+			int actualModCount = modContainers.size() - libraryCount - 1;
+			return NumberFormat.getInstance().format(actualModCount).concat("/") + NumberFormat.getInstance().format(modContainers.size());
+		}
+		else{
+			return NumberFormat.getInstance().format(modContainers.size());
+		}
 	}
 }

--- a/src/main/java/io/github/prospector/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/io/github/prospector/modmenu/config/ModMenuConfig.java
@@ -8,6 +8,18 @@ import java.util.Comparator;
 public class ModMenuConfig {
 	private boolean showLibraries = false;
 	private Sorting sorting = Sorting.ASCENDING;
+	private boolean showActualModCount = false;
+
+	public boolean showActualModCount()
+	{
+		return showActualModCount;
+	}
+
+	public void toggleActualModCount()
+	{
+		showActualModCount = !showActualModCount;
+		ModMenuConfigManager.save();
+	}
 
 	public void toggleShowLibraries() {
 		this.showLibraries = !this.showLibraries;

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.GlStateManager;
 import io.github.prospector.modmenu.ModMenu;
+import io.github.prospector.modmenu.config.ModMenuConfig;
 import io.github.prospector.modmenu.config.ModMenuConfigManager;
 import io.github.prospector.modmenu.util.BadgeRenderer;
 import io.github.prospector.modmenu.util.HardcodedUtil;
@@ -117,6 +118,7 @@ public class ModListScreen extends Screen {
 				super.renderButton(int_1, int_2, float_1);
 			}
 		};
+
 		int urlButtonWidths = paneWidth / 2 - 2;
 		int cappedButtonWidth = urlButtonWidths > 200 ? 200 : urlButtonWidths;
 		ButtonWidget websiteButton = new ButtonWidget(rightPaneX + (urlButtonWidths / 2) - (cappedButtonWidth / 2), paneY + 36, urlButtonWidths > 200 ? 200 : urlButtonWidths, 20,
@@ -154,7 +156,8 @@ public class ModListScreen extends Screen {
 			}
 		};
 		this.children.add(this.searchBox);
-		this.addButton(new ModMenuTexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, FILTERS_BUTTON_LOCATION, 32, 64, button -> {
+		ButtonWidget toggleOptions;
+		this.addButton(toggleOptions=new ModMenuTexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, FILTERS_BUTTON_LOCATION, 32, 64, button -> {
 			filterOptionsShown = !filterOptionsShown;
 		}) {
 			@Override
@@ -165,6 +168,10 @@ public class ModListScreen extends Screen {
 				}
 			}
 		});
+
+		ButtonWidget toggleActualModCount=new ButtonWidget(toggleOptions.x+toggleOptions.getWidth(),toggleOptions.y,20,20,"AMC",buttonWidget -> ModMenuConfigManager.getConfig().toggleActualModCount());
+		addButton(toggleActualModCount);
+
 		String showLibrariesText = I18n.translate("modmenu.showLibraries", I18n.translate("modmenu.showLibraries." + ModMenuConfigManager.getConfig().showLibraries()));
 		String sortingText = I18n.translate("modmenu.sorting", I18n.translate(ModMenuConfigManager.getConfig().getSorting().getTranslationKey()));
 		int showLibrariesWidth = font.getStringWidth(showLibrariesText) + 20;

--- a/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModListScreen.java
@@ -157,7 +157,7 @@ public class ModListScreen extends Screen {
 		};
 		this.children.add(this.searchBox);
 		ButtonWidget toggleOptions;
-		this.addButton(toggleOptions=new ModMenuTexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, FILTERS_BUTTON_LOCATION, 32, 64, button -> {
+		this.addButton(toggleOptions = new ModMenuTexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, FILTERS_BUTTON_LOCATION, 32, 64, button -> {
 			filterOptionsShown = !filterOptionsShown;
 		}) {
 			@Override
@@ -169,7 +169,7 @@ public class ModListScreen extends Screen {
 			}
 		});
 
-		ButtonWidget toggleActualModCount=new ButtonWidget(toggleOptions.x+toggleOptions.getWidth(),toggleOptions.y,20,20,"AMC",buttonWidget -> ModMenuConfigManager.getConfig().toggleActualModCount());
+		ButtonWidget toggleActualModCount = new ButtonWidget(toggleOptions.x + toggleOptions.getWidth(), toggleOptions.y, 20, 20, "AMC", buttonWidget -> ModMenuConfigManager.getConfig().toggleActualModCount());
 		addButton(toggleActualModCount);
 
 		String showLibrariesText = I18n.translate("modmenu.showLibraries", I18n.translate("modmenu.showLibraries." + ModMenuConfigManager.getConfig().showLibraries()));


### PR DESCRIPTION
A small PR; adds a button to toggle the actual mod count (excludes libraries); when true, it will show like "Mods (1/29) loaded", otherwise will show as before.