### PR TITLE
Fix Maven link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A picture's worth 2 words
 ![](https://i.imgur.com/JKEatou.png "Mod Menu")
 
 ### Developers:
-- Mod Menu is on maven at: https://maven.fabricmc.net/io/github/prospector/modmenu/ModMenu/
+- Mod Menu is on maven at: https://maven.fabricmc.net/io/github/prospector/modmenu/
 - The icon comes from the icon specified in your fabric.mod.json (as per the spec)
 - Clientside-only and API badges are defined as custom objects in your fabric.mod.json as such:
 ```json


### PR DESCRIPTION
I don't know if the change to push builds there was intentional, but that's where they are now. Only versions `<= 1.6.3+build.100` reside in that subdirectory.