### PR TITLE
Move background painting to the Screen class's renderBackground method

### DIFF
--- a/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
@@ -1,12 +1,19 @@
 package io.github.prospector.modmenu.gui;
 
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.prospector.modmenu.util.HardcodedUtil;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.widget.EntryListWidget;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.StringRenderable;
+import net.minecraft.util.math.MathHelper;
 
 public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget.DescriptionEntry> {
 
@@ -53,7 +60,39 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 				}
 			}
 		}
-		super.render(matrices, mouseX, mouseY, delta);
+
+		Tessellator tessellator = Tessellator.getInstance();
+		BufferBuilder bufferBuilder = tessellator.getBuffer();
+
+		RenderSystem.depthFunc(515);
+		RenderSystem.disableDepthTest();
+		RenderSystem.enableBlend();
+		RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE);
+		RenderSystem.disableAlphaTest();
+		RenderSystem.shadeModel(7425);
+		RenderSystem.disableTexture();
+
+		bufferBuilder.begin(7, VertexFormats.POSITION_TEXTURE_COLOR);
+		bufferBuilder.vertex(this.left, (this.top + 4), 0.0D).texture(0.0F, 1.0F).color(0, 0, 0, 0).next();
+		bufferBuilder.vertex(this.right, (this.top + 4), 0.0D).texture(1.0F, 1.0F).color(0, 0, 0, 0).next();
+		bufferBuilder.vertex(this.right, this.top, 0.0D).texture(1.0F, 0.0F).color(0, 0, 0, 255).next();
+		bufferBuilder.vertex(this.left, this.top, 0.0D).texture(0.0F, 0.0F).color(0, 0, 0, 255).next();
+		bufferBuilder.vertex(this.left, this.bottom, 0.0D).texture(0.0F, 1.0F).color(0, 0, 0, 255).next();
+		bufferBuilder.vertex(this.right, this.bottom, 0.0D).texture(1.0F, 1.0F).color(0, 0, 0, 255).next();
+		bufferBuilder.vertex(this.right, (this.bottom - 4), 0.0D).texture(1.0F, 0.0F).color(0, 0, 0, 0).next();
+		bufferBuilder.vertex(this.left, (this.bottom - 4), 0.0D).texture(0.0F, 0.0F).color(0, 0, 0, 0).next();
+		tessellator.draw();
+
+		bufferBuilder.begin(7, VertexFormats.POSITION_COLOR);
+		bufferBuilder.vertex(this.left, this.bottom, 0.0D).color(0, 0, 0, 128).next();
+		bufferBuilder.vertex(this.right, this.bottom, 0.0D).color(0, 0, 0, 128).next();
+		bufferBuilder.vertex(this.right, this.top, 0.0D).color(0, 0, 0, 128).next();
+		bufferBuilder.vertex(this.left, this.top, 0.0D).color(0, 0, 0, 128).next();
+		tessellator.draw();
+
+		int k = this.getRowLeft();
+		int l = this.top + 4 - (int)this.getScrollAmount();
+		this.renderList(matrices, k, l, mouseX, mouseY, delta);
 	}
 
 	protected class DescriptionEntry extends EntryListWidget.Entry<DescriptionEntry> {

--- a/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
@@ -93,6 +93,11 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		int k = this.getRowLeft();
 		int l = this.top + 4 - (int)this.getScrollAmount();
 		this.renderList(matrices, k, l, mouseX, mouseY, delta);
+
+		RenderSystem.enableTexture();
+		RenderSystem.shadeModel(7424);
+		RenderSystem.enableAlphaTest();
+		RenderSystem.disableBlend();
 	}
 
 	protected class DescriptionEntry extends EntryListWidget.Entry<DescriptionEntry> {

--- a/src/main/java/io/github/prospector/modmenu/gui/ModsScreen.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/ModsScreen.java
@@ -220,7 +220,7 @@ public class ModsScreen extends Screen {
 
 	@Override
 	public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
-		ModsScreen.overlayBackground(paneWidth, 0, rightPaneX, height, 64, 64, 64, 255, 255);
+		this.renderBackground(matrices);
 		this.tooltip = null;
 		ModListEntry selectedEntry = selected;
 		if (selectedEntry != null) {
@@ -376,6 +376,11 @@ public class ModsScreen extends Screen {
 			return new int[]{total};
 		}
 		return new int[]{visible, total};
+	}
+
+	@Override
+	public void renderBackground(MatrixStack matrices) {
+		ModsScreen.overlayBackground(0, 0, this.width, this.height, 64, 64, 64, 255, 255);
 	}
 
 	static void overlayBackground(int x1, int y1, int x2, int y2, int red, int green, int blue, int startAlpha, int endAlpha) {


### PR DESCRIPTION
Moves background painting to the Screen class's `renderBackground` method. This allows config mod screens to call `parent.renderBackground` to get the same background as ModMenu.

Also fixed a minor issue where the right panel's background was offset from the rest of the background in `ModsScreen.` This is most noticeable when going back and forth between `ModsScreen` and vanilla's config options.

I'll admit this is somewhat selfish, as I want to be able to call `parent.renderBackground` in another mod of mine.