### PR TITLE
Add support for ModUpdater

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -60,5 +60,12 @@
   "description": "Adds a mod menu to view the list of mods you have installed.",
   "mixins": [
     "mixins.modmenu.json"
-  ]
+  ],
+  "custom": {
+    "modupdater": {
+      "strategy": "curseforge",
+      "projectID": 308702,
+      "strict": false
+    }
+  }	
 }


### PR DESCRIPTION
[ModUpdater](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater) is a Fabric mod which automatically checks for and downloads updates to other cooperating Fabric mods.

I created this PR from [the developer documentiation](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater/src/branch/master/MOD_DEVELOPER.md), but I havenʼt personally tested it; you should double-check that it works before merging.

Two possible different versions of this PR:

1. If the name scheme of the JAR files uploaded to CurseForge was changed to `ModMenu <version> for mc-<minecraft version>` (adding the `mc-`), then ModUpdater would be able to detect the full Minecraft version number and the `"strict": false` line could be removed
2. If the name schema for the JAR files on Maven were similarly changed to end in `+<minecraft version>` or `-<minecraft version>`, the update strategy could be Maven instead of CurseForge.