### PR TITLE
Removes unneccessary dependencies on fabric-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-resource-loader-v0:0.2.8+35e08e33a7"
 
 	//Added to fix it failing to compile, needs looking into some more.
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,3 @@ archive_name=modmenu
 minecraft_version=1.16.2-pre1
 yarn_mappings=1.16.2-pre1+build.1
 loader_version=0.9.0+build.204
-fabric_version=0.16.3+build.390-1.16


### PR DESCRIPTION
Currently, ModMenu depends on all modules of the fabric api at compile time, but only fabric-resource-loader at runtime. This PR narrows the compile time dependencies to only fabric-resource-loader.

By depending on the full fabric api, ModMenu prevents using `runClient` on a project with it as a compile dependency on 1.16.3, as gradle includes all dependencies at runtime, including fabric-api-biomes, which does not support 1.16.3 and crashes with a mixin application failure.