### PR TITLE
Update Patchwork support to match its new metadata system.

### DIFF
--- a/src/main/java/io/github/prospector/modmenu/ModMenu.java
+++ b/src/main/java/io/github/prospector/modmenu/ModMenu.java
@@ -101,11 +101,8 @@ public class ModMenu implements ClientModInitializer {
 			if (metadata.containsCustomValue("modmenu:deprecated") && metadata.getCustomValue("modmenu:deprecated").getAsBoolean()) {
 				DEPRECATED_MODS.add(id);
 			}
-			if (metadata.containsCustomValue("patchwork:source") && metadata.getCustomValue("patchwork:source").getAsObject() != null) {
-				CustomValue.CvObject object = metadata.getCustomValue("patchwork:source").getAsObject();
-				if ("forge".equals(object.get("loader").getAsString())) {
-					PATCHWORK_FORGE_MODS.add(id);
-				}
+			if (metadata.containsCustomValue("patchwork:patcherMeta")) {
+				PATCHWORK_FORGE_MODS.add(id);
 			}
 			boolean hasParent = false;
 			if (metadata.containsCustomValue("modmenu:parent")) {


### PR DESCRIPTION
If this could be backported to 1.15 (and 1.14) i'd appreciate it, but I'm okay with keeping the legacy detection in place until we hit 1.16