### PR TITLE
Fixes the rendering of long descriptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=1.14.10
+mod_version=1.14.11
 maven_group=io.github.prospector
 archive_name=modmenu
 

--- a/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
@@ -54,7 +54,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			}
 			if (lastSelected != null && description != null && !description.isEmpty()) {
 				for (OrderedText line : textRenderer.wrapLines(new LiteralText(description.replaceAll("\n", "\n\n")), getRowWidth())) {
-					children().add(new DescriptionEntry(line));
+					children().add(new DescriptionEntry(line, this));
 				}
 			}
 		}
@@ -99,15 +99,20 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 	}
 
 	protected class DescriptionEntry extends EntryListWidget.Entry<DescriptionEntry> {
+		private final DescriptionListWidget widget;
 		protected OrderedText text;
 
-		public DescriptionEntry(OrderedText text) {
+		public DescriptionEntry(OrderedText text, DescriptionListWidget widget) {
 			this.text = text;
+			this.widget = widget;
 		}
 
 		@Override
 		public void render(MatrixStack matrices, int index, int y, int x, int itemWidth, int itemHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-			MinecraftClient.getInstance().textRenderer.drawWithShadow(matrices, text, x, y, 0xAAAAAA);
+			if (widget.top > y || widget.bottom - textRenderer.fontHeight < y) {
+				return;
+			}
+			textRenderer.drawWithShadow(matrices, text, x, y, 0xAAAAAA);
 		}
 	}
 

--- a/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
+++ b/src/main/java/io/github/prospector/modmenu/gui/DescriptionListWidget.java
@@ -12,6 +12,7 @@ import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.OrderedText;
+import net.minecraft.util.math.MathHelper;
 
 public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget.DescriptionEntry> {
 
@@ -53,7 +54,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 				description = HardcodedUtil.getHardcodedDescription(id);
 			}
 			if (lastSelected != null && description != null && !description.isEmpty()) {
-				for (OrderedText line : textRenderer.wrapLines(new LiteralText(description.replaceAll("\n", "\n\n")), getRowWidth())) {
+				for (OrderedText line : textRenderer.wrapLines(new LiteralText(description.replaceAll("\n", "\n\n")), getRowWidth() - 5)) {
 					children().add(new DescriptionEntry(line, this));
 				}
 			}
@@ -89,13 +90,44 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		tessellator.draw();
 
 		int k = this.getRowLeft();
-		int l = this.top + 4 - (int)this.getScrollAmount();
+		int l = this.top + 4 - (int) this.getScrollAmount();
 		this.renderList(matrices, k, l, mouseX, mouseY, delta);
+		this.renderScrollBar(bufferBuilder, tessellator);
 
 		RenderSystem.enableTexture();
 		RenderSystem.shadeModel(7424);
 		RenderSystem.enableAlphaTest();
 		RenderSystem.disableBlend();
+	}
+
+	public void renderScrollBar(BufferBuilder bufferBuilder, Tessellator tessellator) {
+		int scrollbarStartX = this.getScrollbarPositionX();
+		int scrollbarEndX = scrollbarStartX + 6;
+		int maxScroll = this.getMaxScroll();
+		if (maxScroll > 0) {
+			RenderSystem.disableTexture();
+			int p = (int) ((float) ((this.bottom - this.top) * (this.bottom - this.top)) / (float) this.getMaxPosition());
+			p = MathHelper.clamp(p, 32, this.bottom - this.top - 8);
+			int q = (int) this.getScrollAmount() * (this.bottom - this.top - p) / maxScroll + this.top;
+			if (q < this.top) {
+				q = this.top;
+			}
+
+			bufferBuilder.begin(7, VertexFormats.POSITION_TEXTURE_COLOR);
+			bufferBuilder.vertex(scrollbarStartX, this.bottom, 0.0D).texture(0.0F, 1.0F).color(0, 0, 0, 255).next();
+			bufferBuilder.vertex(scrollbarEndX, this.bottom, 0.0D).texture(1.0F, 1.0F).color(0, 0, 0, 255).next();
+			bufferBuilder.vertex(scrollbarEndX, this.top, 0.0D).texture(1.0F, 0.0F).color(0, 0, 0, 255).next();
+			bufferBuilder.vertex(scrollbarStartX, this.top, 0.0D).texture(0.0F, 0.0F).color(0, 0, 0, 255).next();
+			bufferBuilder.vertex(scrollbarStartX, q + p, 0.0D).texture(0.0F, 1.0F).color(128, 128, 128, 255).next();
+			bufferBuilder.vertex(scrollbarEndX, q + p, 0.0D).texture(1.0F, 1.0F).color(128, 128, 128, 255).next();
+			bufferBuilder.vertex(scrollbarEndX, q, 0.0D).texture(1.0F, 0.0F).color(128, 128, 128, 255).next();
+			bufferBuilder.vertex(scrollbarStartX, q, 0.0D).texture(0.0F, 0.0F).color(128, 128, 128, 255).next();
+			bufferBuilder.vertex(scrollbarStartX, q + p - 1, 0.0D).texture(0.0F, 1.0F).color(192, 192, 192, 255).next();
+			bufferBuilder.vertex(scrollbarEndX - 1, q + p - 1, 0.0D).texture(1.0F, 1.0F).color(192, 192, 192, 255).next();
+			bufferBuilder.vertex(scrollbarEndX - 1, q, 0.0D).texture(1.0F, 0.0F).color(192, 192, 192, 255).next();
+			bufferBuilder.vertex(scrollbarStartX, q, 0.0D).texture(0.0F, 0.0F).color(192, 192, 192, 255).next();
+			tessellator.draw();
+		}
 	}
 
 	protected class DescriptionEntry extends EntryListWidget.Entry<DescriptionEntry> {


### PR DESCRIPTION
This closes #172 by creating a boundary for the description to render in and renders the scrollbar again.
Result:
![Screenshot 2020-11-22 at 16 24 17](https://user-images.githubusercontent.com/13536793/99907801-490f4a00-2cdf-11eb-96b4-e887aa11db9c.png)

