### PR TITLE
Allow a more "dynamic" provider factories

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
@@ -30,8 +30,8 @@ public class ModSearch {
 				|| modId.toLowerCase(Locale.ROOT).contains(query) // Search mod name
 				|| authorMatches(mod, query) // Search via author
 				|| (mod.getBadges().contains(Mod.Badge.LIBRARY) && "api library".contains(query)) // Search for lib mods
-				|| ("patchwork forge".contains(query) && mod.getBadges().contains(Mod.Badge.PATCHWORK_FORGE)) // Search for clientside mods
-				|| ("deprecated".contains(query) && mod.getBadges().contains(Mod.Badge.DEPRECATED)) // Search for clientside mods
+				|| ("patchwork forge".contains(query) && mod.getBadges().contains(Mod.Badge.PATCHWORK_FORGE)) // Search for patchwork mods
+				|| ("deprecated".contains(query) && mod.getBadges().contains(Mod.Badge.DEPRECATED)) // Search for deprecated mods
 				|| ("clientside client-side".contains(query) && mod.getBadges().contains(Mod.Badge.CLIENT)) // Search for clientside mods
 				|| ("configurations configs configures configurable".contains(query) && screen.getConfigScreenCache().get(modId) != null) // Search for mods that can be configured
 		) {


### PR DESCRIPTION
Closes architectury/architectury-api#61

Currently, the provided factories are gathered on startup, this disallows a more "dynamic" provided factories.

## Alternative fixes
- Delay the gathering of the factories until the first time the ModsScreen is initialized