### PR TITLE
Make mod button compatible with hidden buttons

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
@@ -40,11 +40,16 @@ public class ModMenuEventHandler {
 			final List<AbstractButtonWidget> buttons = Screens.getButtons(screen);
 			int modsButtonIndex = -1;
 			final int spacing = 24;
-			final int buttonsY = screen.height / 4 + 48;
+			int buttonsY = screen.height / 4 + 48;
 			for (int i = 0; i < buttons.size(); i++) {
 				AbstractButtonWidget button = buttons.get(i);
 				if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					shiftButtons(button, modsButtonIndex == -1, spacing);
+					if (button.visible) {
+						shiftButtons(button, modsButtonIndex == -1, spacing);
+						if (modsButtonIndex == -1) {
+							buttonsY = button.y;
+						}
+					}
 				}
 				if (buttonHasText(button, "menu.online")) {
 					if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.REPLACE_REALMS) {
@@ -54,16 +59,19 @@ public class ModMenuEventHandler {
 							button.setWidth(98);
 						}
 						modsButtonIndex = i + 1;
+						if (button.visible) {
+							buttonsY = button.y;
+						}
 					}
 				}
 			}
 			if (modsButtonIndex != -1) {
 				if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 100, buttonsY + spacing * 3 - (spacing / 2), 200, 20, ModMenuApi.createModsButtonText(), screen));
+					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 100, buttonsY + spacing, 200, 20, ModMenuApi.createModsButtonText(), screen));
 				} else if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.SHRINK) {
-					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 + 2, buttonsY + spacing * 2, 98, 20, ModMenuApi.createModsButtonText(), screen));
+					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 + 2, buttonsY, 98, 20, ModMenuApi.createModsButtonText(), screen));
 				} else if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.ICON) {
-					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 104, buttonsY + spacing * 2, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().openScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
+					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 104, buttonsY, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().openScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
 				}
 			}
 		}
@@ -74,12 +82,17 @@ public class ModMenuEventHandler {
 			final List<AbstractButtonWidget> buttons = Screens.getButtons(screen);
 			int modsButtonIndex = -1;
 			final int spacing = 24;
-			final int buttonsY = screen.height / 4 + 8;
+			int buttonsY = screen.height / 4 + 8;
 			ModMenuConfig.ModsButtonStyle style = ModMenuConfig.MODS_BUTTON_STYLE.getValue().forGameMenu();
 			for (int i = 0; i < buttons.size(); i++) {
 				AbstractButtonWidget button = buttons.get(i);
 				if (style == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					shiftButtons(button, modsButtonIndex == -1, spacing);
+					if (button.visible) {
+						shiftButtons(button, modsButtonIndex == -1, spacing);
+						if (modsButtonIndex == -1) {
+							buttonsY = button.y;
+						}
+					}
 				}
 				if (buttonHasText(button, "menu.reportBugs")) {
 					modsButtonIndex = i + 1;
@@ -87,12 +100,15 @@ public class ModMenuEventHandler {
 						buttons.set(i, new ModMenuButtonWidget(button.x, button.y, button.getWidth(), button.getHeight(), ModMenuApi.createModsButtonText(), screen));
 					} else {
 						modsButtonIndex = i + 1;
+						if (button.visible) {
+							buttonsY = button.y;
+						}
 					}
 				}
 			}
 			if (modsButtonIndex != -1) {
 				if (style == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 102, buttonsY + spacing * 3 - (spacing / 2), 204, 20, ModMenuApi.createModsButtonText(), screen));
+					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 102, buttonsY + spacing, 204, 20, ModMenuApi.createModsButtonText(), screen));
 				} else if (style == ModMenuConfig.ModsButtonStyle.ICON) {
 					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 4 + 100 + 2, screen.height / 4 + 72 + -16, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().openScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
 				}


### PR DESCRIPTION
The mod button is now dynamically placed based on surrounding visible buttons, other buttons are also shifted dynamically.

In the case of MinimalMenu this fixes the CLASSIC and ICON style in all cases, and REPLACE_REALMS and SHRINK style if the realms button hasn't been hidden. The main menu and pause menu were both tested.

Fixes https://github.com/TerraformersMC/ModMenu/issues/196 / https://github.com/TomB-134/MinimalMenu/issues/7