### PR TITLE
Change from "menu" to "menù" in Italian translation.

### DIFF
--- a/src/main/resources/assets/modmenu/lang/it_it.json
+++ b/src/main/resources/assets/modmenu/lang/it_it.json
@@ -1,6 +1,6 @@
 {
   "modmenu.title": "Mod",
-  "modmenu.descriptionTranslation.modmenu": "Aggiunge un menu dove puoi vedere una lista di tutte le mod installate",
+  "modmenu.descriptionTranslation.modmenu": "Aggiunge un menù dove puoi vedere una lista di tutte le mod installate",
   "modmenu.loaded": "(%s Caricate)",
   "modmenu.config": "Configura mod",
   "modmenu.modsFolder": "Apri la cartella delle mod",


### PR DESCRIPTION
In Italian, writing menù is more correct than menu ( see https://it.wikipedia.org/wiki/Men%C3%B9 ).
