### PR TITLE
Fix: Only add 'v' to version if the mod has not done so itself

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.config.ModMenuConfigManager;
-import com.terraformersmc.modmenu.config.option.ConfigOptionStorage;
 import com.terraformersmc.modmenu.gui.widget.DescriptionListWidget;
 import com.terraformersmc.modmenu.gui.widget.ModListWidget;
 import com.terraformersmc.modmenu.gui.widget.ModMenuTexturedButtonWidget;
@@ -15,7 +14,6 @@ import com.terraformersmc.modmenu.util.TranslationUtil;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModBadgeRenderer;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.ConfirmChatLinkScreen;
 import net.minecraft.client.gui.screen.ConfirmScreen;
@@ -331,7 +329,7 @@ public class ModsScreen extends Screen {
 				modBadgeRenderer.draw(matrices, mouseX, mouseY);
 			}
 			if (mod.isReal()) {
-				textRenderer.draw(matrices, "v" + mod.getVersion(), x + imageOffset, paneY + 2 + lineSpacing, 0x808080);
+				textRenderer.draw(matrices, mod.getPrefixedVersion(), x + imageOffset, paneY + 2 + lineSpacing, 0x808080);
 			}
 			String authors;
 			List<String> names = mod.getAuthors();

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
@@ -80,7 +80,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 			}
 			DrawingUtil.drawWrappedString(matrices, summary, (x + iconSize + 3 + 4), (y + client.textRenderer.fontHeight + 2), rowWidth - iconSize - 7, 2, 0x808080);
 		} else {
-			DrawingUtil.drawWrappedString(matrices, "v" + mod.getVersion(), (x + iconSize + 3), (y + client.textRenderer.fontHeight + 2), rowWidth - iconSize - 7, 2, 0x808080);
+			DrawingUtil.drawWrappedString(matrices, mod.getPrefixedVersion(), (x + iconSize + 3), (y + client.textRenderer.fontHeight + 2), rowWidth - iconSize - 7, 2, 0x808080);
 		}
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -29,6 +29,9 @@ public interface Mod {
 	String getVersion();
 
 	@NotNull
+	String getPrefixedVersion();
+
+	@NotNull
 	List<String> getAuthors();
 
 	@NotNull

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
@@ -74,6 +74,11 @@ public class FabricDummyParentMod implements Mod {
 	}
 
 	@Override
+	public @NotNull String getPrefixedVersion() {
+		return "";
+	}
+
+	@Override
 	public @NotNull List<String> getAuthors() {
 		return new ArrayList<>();
 	}

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -195,6 +195,21 @@ public class FabricMod implements Mod {
 		return metadata.getVersion().getFriendlyString();
 	}
 
+	/**
+	 * A styled and prefixed version string.
+	 */
+	public @NotNull String getPrefixedVersion() {
+		String version = getVersion().trim();
+		if (version.startsWith("version")) {
+			version = "v" + version.substring("version".length());
+		} else if (version.startsWith("ver")) {
+			version = "v" + version.substring("ver".length());
+		} else if (!version.startsWith("v")) {
+			version = "v" + version;
+		}
+		return version.trim();
+	}
+
 	@Override
 	public @NotNull List<String> getAuthors() {
 		List<String> authors = metadata.getAuthors().stream().map(Person::getName).collect(Collectors.toList());


### PR DESCRIPTION
ModMenu was always just adding a "v" character in front of the version string. Funnily enough, ModMenu itself already adds a 'v' to its version so it's effectively doubled. See the screenshot below of how it used to look:
![image](https://user-images.githubusercontent.com/43609023/130806758-0e3f363f-87a7-4807-ac1e-5a3d6f2820d5.png)
