### PR TITLE
Add a mod settings screen with convenient access to mod configuration

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
@@ -21,6 +21,7 @@ public class ModMenuConfig {
 	public static final BooleanConfigOption COMPACT_LIST = new BooleanConfigOption("compact_list", false);
 	public static final BooleanConfigOption COUNT_CHILDREN = new BooleanConfigOption("count_children", true);
 	public static final EnumConfigOption<ModsButtonStyle> MODS_BUTTON_STYLE = new EnumConfigOption<>("mods_button_style", ModsButtonStyle.CLASSIC);
+	public static final BooleanConfigOption SHOW_CONFIG_BUTTON = new BooleanConfigOption("show_config_button", true);
 	public static final BooleanConfigOption COUNT_HIDDEN_MODS = new BooleanConfigOption("count_hidden_mods", true);
 	public static final EnumConfigOption<ModCountLocation> MOD_COUNT_LOCATION = new EnumConfigOption<>("mod_count_location", ModCountLocation.TITLE_SCREEN);
 	public static final BooleanConfigOption HIDE_MOD_LINKS = new BooleanConfigOption("hide_mod_links", false);

--- a/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
@@ -6,6 +6,7 @@ import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import com.terraformersmc.modmenu.gui.widget.ModMenuButtonWidget;
 import com.terraformersmc.modmenu.gui.widget.ModMenuTexturedButtonWidget;
+import com.terraformersmc.modmenu.gui.widget.ModsConfigButtonWidget;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.client.MinecraftClient;
@@ -52,7 +53,15 @@ public class ModMenuEventHandler {
 				}
 				if (buttonHasText(button, "menu.online")) {
 					if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.REPLACE_REALMS) {
-						buttons.set(i, new ModMenuButtonWidget(button.x, button.y, button.getWidth(), button.getHeight(), ModMenuApi.createModsButtonText(), screen));
+						if (ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+							buttons.set(i, new ModMenuButtonWidget(button.x, button.y, 98, button.getHeight(), ModMenuApi.createModsButtonText(), screen));
+							modsButtonIndex = i + 1;
+							if (button.visible) {
+								buttonsY = button.y;
+							}
+						} else {
+							buttons.set(i, new ModMenuButtonWidget(button.x, button.y, button.getWidth(), button.getHeight(), ModMenuApi.createModsButtonText(), screen));
+						}
 					} else {
 						if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.SHRINK) {
 							button.setWidth(98);
@@ -61,16 +70,28 @@ public class ModMenuEventHandler {
 						if (button.visible) {
 							buttonsY = button.y;
 						}
+						if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.CLASSIC && ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+							modsButtonIndex++;
+						}
 					}
 				}
 			}
 			if (modsButtonIndex != -1) {
 				if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 100, buttonsY + spacing, 200, 20, ModMenuApi.createModsButtonText(), screen));
+					if (ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+						buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 100, buttonsY + spacing, 98, 20, ModMenuApi.createModsButtonText(), screen));
+						buttons.add(modsButtonIndex - 1, new ModsConfigButtonWidget(screen.width / 2 + 2, buttonsY + spacing, 98, 20, new TranslatableText("modmenu.config.buttton"), screen));
+					} else {
+						buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 100, buttonsY + spacing, 200, 20, ModMenuApi.createModsButtonText(), screen));
+					}
 				} else if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.SHRINK) {
 					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 + 2, buttonsY, 98, 20, ModMenuApi.createModsButtonText(), screen));
 				} else if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.ICON) {
 					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 104, buttonsY, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().openScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
+				} else if (ModMenuConfig.MODS_BUTTON_STYLE.getValue() == ModMenuConfig.ModsButtonStyle.REPLACE_REALMS) {
+					if (ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+						buttons.add(modsButtonIndex, new ModsConfigButtonWidget(screen.width / 2 + 2, buttonsY, 98, 20, new TranslatableText("modmenu.config.buttton"), screen));
+					}
 				}
 			}
 		}
@@ -102,12 +123,20 @@ public class ModMenuEventHandler {
 						if (button.visible) {
 							buttonsY = button.y;
 						}
+						if (style == ModMenuConfig.ModsButtonStyle.CLASSIC && ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+							modsButtonIndex++;
+						}
 					}
 				}
 			}
 			if (modsButtonIndex != -1) {
 				if (style == ModMenuConfig.ModsButtonStyle.CLASSIC) {
-					buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 102, buttonsY + spacing, 204, 20, ModMenuApi.createModsButtonText(), screen));
+					if (ModMenuConfig.SHOW_CONFIG_BUTTON.getValue()) {
+						buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 102, buttonsY + spacing, 98, 20, ModMenuApi.createModsButtonText(), screen));
+						buttons.add(modsButtonIndex - 1, new ModsConfigButtonWidget(screen.width / 2 + 4, buttonsY + spacing, 98, 20, new TranslatableText("modmenu.config.buttton"), screen));
+					} else {
+						buttons.add(modsButtonIndex, new ModMenuButtonWidget(screen.width / 2 - 102, buttonsY + spacing, 204, 20, ModMenuApi.createModsButtonText(), screen));
+					}
 				} else if (style == ModMenuConfig.ModsButtonStyle.ICON) {
 					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 4 + 100 + 2, screen.height / 4 + 72 + -16, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().openScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
 				}

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsConfigScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsConfigScreen.java
@@ -1,0 +1,86 @@
+package com.terraformersmc.modmenu.gui;
+
+import com.terraformersmc.modmenu.ModMenu;
+import com.terraformersmc.modmenu.config.ModMenuConfig;
+import com.terraformersmc.modmenu.util.mod.Mod;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.widget.ButtonListWidget;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.option.GameOptions;
+import net.minecraft.client.option.Option;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ModsConfigScreen extends Screen {
+	private final Screen previous;
+	private ButtonListWidget list;
+
+	public ModsConfigScreen(Screen previous) {
+		super(new TranslatableText("modmenu.config.title"));
+		this.previous = previous;
+	}
+
+	protected void init() {
+		this.list = new ButtonListWidget(this.client, this.width, this.height, 32, this.height - 32, 25);
+		this.list.addAll(getAllModConfigOptions());
+
+		this.addSelectableChild(this.list);
+		this.addDrawableChild(new ButtonWidget(this.width / 2 - 100, this.height - 27, 200, 20,
+				ScreenTexts.DONE, (button) -> this.client.openScreen(this.previous)));
+	}
+
+	private Option[] getAllModConfigOptions() {
+		List<Option> options = new LinkedList<>();
+		for (Mod mod : ModMenu.MODS.values().stream().sorted(ModMenuConfig.SORTING.getValue().getComparator()).collect(Collectors.toList())) {
+			try {
+				Screen configScreen = ModMenu.getConfigScreen(mod.getId(), this);
+				if (configScreen != null && !mod.getId().equals("minecraft")) {
+					options.add(new ModConfigOption(mod, configScreen));
+				}
+			} catch (NoClassDefFoundError e) {
+				ModMenu.LOGGER.warn("The '" + mod.getId() + "' mod config screen is not available because " + e.getLocalizedMessage() + " is missing.");
+			} catch (Throwable e) {
+				ModMenu.LOGGER.error("Error from mod '" + mod.getId() + "'", e);
+			}
+		}
+		return options.toArray(new Option[0]);
+	}
+
+	public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+		this.renderBackground(matrices);
+		this.list.render(matrices, mouseX, mouseY, delta);
+		drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 5, 0xffffff);
+		super.render(matrices, mouseX, mouseY, delta);
+	}
+
+	public void onClose() {
+		this.client.openScreen(this.previous);
+	}
+
+	class ModConfigOption extends Option {
+		private final Mod mod;
+		private final Screen configScreen;
+
+		public ModConfigOption(Mod mod, Screen configScreen) {
+			super(mod.getId());
+			this.mod = mod;
+			this.configScreen = configScreen;
+		}
+
+		@Override
+		public ClickableWidget createButton(GameOptions options, int x, int y, int width) {
+			return new ButtonWidget(x, y, width, 20, Text.of(this.mod.getName()), this::onPress);
+		}
+
+		private void onPress(ButtonWidget buttonWidget) {
+			client.openScreen(this.configScreen);
+		}
+	}
+}

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModsConfigButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModsConfigButtonWidget.java
@@ -1,0 +1,13 @@
+package com.terraformersmc.modmenu.gui.widget;
+
+import com.terraformersmc.modmenu.gui.ModsConfigScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+public class ModsConfigButtonWidget extends ButtonWidget {
+	public ModsConfigButtonWidget(int x, int y, int width, int height, Text text, Screen screen) {
+		super(x, y, width, height, text, button -> MinecraftClient.getInstance().openScreen(new ModsConfigScreen(screen)));
+	}
+}

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -5,6 +5,8 @@
   "modmenu.loaded.69.secret": "(%s Loaded...nice)",
   "modmenu.loaded.420.secret": "(%s Loaded...blaze it)",
   "modmenu.loaded.short": "(%s)",
+  "modmenu.config.buttton": "Mod Settings...",
+  "modmenu.config.title": "Mod Settings",
   "modmenu.config": "Edit Config",
   "modmenu.modsFolder": "Open Mods Folder",
   "modmenu.configsFolder": "Open Configs Folder",
@@ -101,5 +103,8 @@
   "option.modmenu.mods_button_style.classic": "Below Realms",
   "option.modmenu.mods_button_style.replace_realms": "Replace Realms",
   "option.modmenu.mods_button_style.shrink": "Adjacent",
-  "option.modmenu.mods_button_style.icon": "Icon"
+  "option.modmenu.mods_button_style.icon": "Icon",
+  "option.modmenu.show_config_button": "Config Button",
+  "option.modmenu.show_config_button.true": "Shown",
+  "option.modmenu.show_config_button.false": "Hidden"
 }


### PR DESCRIPTION
I often find myself going to the ModMenu list of modules, searching through the list to find a specific mod, just to press the configuration button for that mod. Some mods have hotkeys to go directly to their configuration screen, but it's hard to remember them all, and after a while, hotkeys tend to become a precious resource in modded Minecraft.

This PR is a response to that problem. A separate "Mod Settings" screen is created, with easy access from the in-game menu. This screen is a standard Minecraft scrollable options list, with a button for each mod with a configuration screen. The button takes the user directly to the mod's configuration screen. This creates a very integrated, "vanilla feel" experience for changing mod settings.

The way the "Mod Settings" button is added is a bit more complex than what I'd wished for. The core problem is that the current way of determining button placement and size would need a redesign. A single multi-value is supposed to determine both the placement of the title menu button and the in-game menu button. This makes options such as "Adjacent" behave quite weirdly (in the title menu it sits next to "Realms", in the in-game menu it replaces the "Report bug" button (much to my surprise!) 

I tried to stay close to what I believe was the design intent of these placement heuristics, but I think a follow-up PR which clears up the button placement logic would be a good thing. 

There is a separate configuration to enable/disable the "Mod Settings" button. (Note that the mod button placement heuristic must allow for the button to be displayed, otherwise it is not showing even if the configuration flag is true.