### PR TITLE
Change Minecraft license to Minecraft EULA

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -229,7 +229,7 @@ public class FabricMod implements Mod {
 	@Override
 	public @NotNull Set<String> getLicense() {
 		if ("minecraft".equals(getId())) {
-			return Sets.newHashSet("All Rights Reserved");
+			return Sets.newHashSet("Minecraft EULA");
 		}
 		return Sets.newHashSet(metadata.getLicense());
 	}


### PR DESCRIPTION
Minecraft isn't fully ARR, even if its license is very restrictive. See <https://www.minecraft.net/en-us/eula>.