### PR TITLE
Return to the Mods screen after watching Minecraft Credits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ maven_group=com.terraformersmc
 archive_name=modmenu
 
 minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.4
+yarn_mappings=1.18.1+build.18
 loader_version=0.12.12
 fabric_version=0.44.0+1.18
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -15,11 +15,7 @@ import net.minecraft.client.gui.screen.CreditsScreen;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.gui.widget.EntryListWidget;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.Tessellator;
-import net.minecraft.client.render.VertexFormat;
-import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.render.*;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
@@ -263,9 +259,20 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		@Override
 		public boolean mouseClicked(double mouseX, double mouseY, int button) {
 			if (isMouseOver(mouseX, mouseY)) {
-				client.setScreen(new CreditsScreen(false, Runnables.doNothing()));
+				client.setScreen(new MinecraftCredits(false));
 			}
 			return super.mouseClicked(mouseX, mouseY, button);
+		}
+
+		class MinecraftCredits extends CreditsScreen {
+			public MinecraftCredits(boolean endCredits) {
+				super(endCredits, Runnables.doNothing());
+			}
+
+			@Override
+			public void onClose() {
+				client.setScreen(parent);
+			}
 		}
 	}
 


### PR DESCRIPTION
After using __View Credits__, you get Credits Screen that sets clients screen to null, which can be distracting and unpractical.
This is my mixin-free implementation to change this.

![image](https://user-images.githubusercontent.com/69470758/150122426-d8d614b8-d69c-40a1-b564-da38fd72c913.png)

_P.S. I created an unnecessary commit which is the gradle.properties one, I didn't mention to propose it in pull request, but that's how git works. I could work that out, but I think i'ts not a problem to skip it._