### PR TITLE
[1.18] Add keybind for opening the mod menu screen.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,11 @@ dependencies {
 	mappings "net.fabricmc:yarn:$project.yarn_mappings:v2"
 
 	mod "fabric-loader", "net.fabricmc:fabric-loader:$project.loader_version"
-    includeMod "fabric-api", fabricApi.module("fabric-api-base", project.fabric_version)
-    includeMod "fabric-api", fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
-    includeMod "fabric-api", fabricApi.module("fabric-screen-api-v1", project.fabric_version)
+	includeMod "fabric-api", fabricApi.module("fabric-api-base", project.fabric_version)
+	includeMod "fabric-api", fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
+	includeMod "fabric-api", fabricApi.module("fabric-screen-api-v1", project.fabric_version)
+	includeMod "fabric-api", fabricApi.module("fabric-key-binding-api-v1", project.fabric_version)
+	includeMod "fabric-api", fabricApi.module("fabric-lifecycle-events-v1", project.fabric_version)
 	compileOnly "org.quiltmc:quilt-loader:$project.quilt_loader_version"
 }
 

--- a/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
@@ -6,6 +6,8 @@ import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import com.terraformersmc.modmenu.gui.widget.ModMenuButtonWidget;
 import com.terraformersmc.modmenu.gui.widget.ModMenuTexturedButtonWidget;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.client.MinecraftClient;
@@ -13,17 +15,28 @@ import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.List;
 
 public class ModMenuEventHandler {
 	private static final Identifier FABRIC_ICON_BUTTON_LOCATION = new Identifier(ModMenu.MOD_ID, "textures/gui/mods_button.png");
+	private static KeyBinding MENU_KEY_BIND;
 
 	public static void register() {
+		MENU_KEY_BIND = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+				"key.modmenu.open_menu",
+				InputUtil.Type.KEYSYM,
+				GLFW.GLFW_KEY_R,
+				"category.modmenu.name"
+		));
 		ScreenEvents.AFTER_INIT.register(ModMenuEventHandler::afterScreenInit);
+		ClientTickEvents.END_CLIENT_TICK.register(ModMenuEventHandler::onClientEndTick);
 	}
 
 	public static void afterScreenInit(MinecraftClient client, Screen screen, int scaledWidth, int scaledHeight) {
@@ -112,6 +125,12 @@ public class ModMenuEventHandler {
 					buttons.add(modsButtonIndex, new ModMenuTexturedButtonWidget(screen.width / 2 + 4 + 100 + 2, screen.height / 4 + 72 + -16, 20, 20, 0, 0, FABRIC_ICON_BUTTON_LOCATION, 32, 64, button -> MinecraftClient.getInstance().setScreen(new ModsScreen(screen)), ModMenuApi.createModsButtonText()));
 				}
 			}
+		}
+	}
+
+	private static void onClientEndTick(MinecraftClient client) {
+		while (MENU_KEY_BIND.wasPressed()) {
+			client.setScreen(new ModsScreen(client.currentScreen));
 		}
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/event/ModMenuEventHandler.java
@@ -32,7 +32,7 @@ public class ModMenuEventHandler {
 		MENU_KEY_BIND = KeyBindingHelper.registerKeyBinding(new KeyBinding(
 				"key.modmenu.open_menu",
 				InputUtil.Type.KEYSYM,
-				GLFW.GLFW_KEY_R,
+				InputUtil.UNKNOWN_KEY.getCode(),
 				"category.modmenu.name"
 		));
 		ScreenEvents.AFTER_INIT.register(ModMenuEventHandler::afterScreenInit);

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -1,7 +1,8 @@
 {
+  "category.modmenu.name": "Mod Menu",
+  "key.modmenu.open_menu": "Opens the Mod Menu screen.",
   "modmenu.title": "Mods",
   "modmenu.descriptionTranslation.modmenu": "Adds a mod menu to view the list of mods you have installed.",
-
   "modmenu.loaded": "(%s Loaded)",
   "modmenu.loaded.short": "(%s)",
   "modmenu.loaded.69.secret": "(%s Loaded...nice)",

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -1,6 +1,6 @@
 {
   "category.modmenu.name": "Mod Menu",
-  "key.modmenu.open_menu": "Opens the Mod Menu screen.",
+  "key.modmenu.open_menu": "Open Mod Menu",
   "modmenu.title": "Mods",
   "modmenu.descriptionTranslation.modmenu": "Adds a mod menu to view the list of mods you have installed.",
   "modmenu.loaded": "(%s Loaded)",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,8 @@
   "depends": {
     "fabric-resource-loader-v0": "*",
     "fabric-screen-api-v1": ">=1.0.4",
+    "fabric-key-binding-api-v1": "*",
+    "fabric-lifecycle-events-v1": "*",
     "fabricloader": ">=0.12.6",
     "minecraft": ">=1.18"
   },
@@ -83,7 +85,8 @@
     "OroArmor",
     "Vaerian",
     "spnda",
-    "Jab125"
+    "Jab125",
+    "legenden"
   ],
   "description": "Adds a mod menu to view the list of mods you have installed.",
   "mixins": [


### PR DESCRIPTION
This includes the feature requested and closes #403

This is my first interaction with fabric, but hopefully not my last.
Feel free to comment on my approach, or the default keybind for the key.

Also I'm unsure how translations work for this specific project, so I'm not sure if I should add the translations keys somewhere (en file), or if they need to be added through Weblate.

If accepted, I'll be happy to port to 1.16 and 1.19 :D