### PR TITLE
Fix quilt mod discarding fabric sha512, checking bundled mods for updates

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
@@ -14,6 +14,7 @@ import org.quiltmc.loader.api.QuiltLoader;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -70,18 +71,20 @@ public class QuiltMod extends FabricMod {
 		if (fabricResult == null) {
 			ModrinthUtil.LOGGER.debug("Checking {}", getId());
 			if (container.getSourceType().equals(ModContainer.BasicSourceType.NORMAL_QUILT) || container.getSourceType().equals(ModContainer.BasicSourceType.NORMAL_FABRIC)) {
-				var path = container.getSourcePaths().stream()
-						.filter(p -> p.stream().anyMatch(p2 -> p2.toString().toLowerCase(Locale.ROOT).endsWith(".jar"))).findFirst().orElse(Collections.emptyList())
-						.stream().filter(p -> p.toString().toLowerCase(Locale.ROOT).endsWith(".jar")).findFirst();
-				if (path.isPresent() && path.get().getFileSystem() == FileSystems.getDefault()) {
-					var file = path.get().toFile();
-					if (file.isFile()) {
-						ModrinthUtil.LOGGER.debug("	Found {} hash", getId());
-						return Files.asByteSource(file).hash(Hashing.sha512()).toString();
+				for (var paths : container.getSourcePaths()) {
+					List<Path> jars = paths.stream().filter(p -> p.toString().toLowerCase(Locale.ROOT).endsWith(".jar")).toList();
+
+					if (jars.size() == 1 && jars.get(0).getFileSystem() == FileSystems.getDefault()) {
+						var file = jars.get(0).toFile();
+
+						if (file.exists()) {
+							ModrinthUtil.LOGGER.debug("Found {} hash", getId());
+							return Files.asByteSource(file).hash(Hashing.sha512()).toString();
+						}
 					}
 				}
 			}
 		}
-		return null;
+		return fabricResult;
 	}
 }


### PR DESCRIPTION
Fixes quilt mod not returning the `fabricResult` and makes it ignore bundled mods on loader `>=0.18.1` by ensuring only a single `.jar` source file exists instead of simply using the first `.jar`.

I've tested this on both `0.17.11` and `0.18.1-beta.78` and it works fine.