### PR TITLE
Update mod to Minecraft 1.19.4 pre-release 4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=23w07a
-yarn_mappings=23w07a+build.1
-loader_version=0.14.14
-fabric_version=0.74.1+1.19.4
+minecraft_version=1.19.4-pre4
+yarn_mappings=1.19.4-pre4+build.1
+loader_version=0.14.17
+fabric_version=0.75.3+1.19.4
 quilt_loader_version=0.17.7
 
 # Project Metadata

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
@@ -5,8 +5,8 @@ import com.terraformersmc.modmenu.config.ModMenuConfigManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.GameOptionsScreen;
-import net.minecraft.client.gui.widget.ButtonListWidget;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.OptionListWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Text;
@@ -14,7 +14,7 @@ import net.minecraft.text.Text;
 public class ModMenuOptionsScreen extends GameOptionsScreen {
 
 	private Screen previous;
-	private ButtonListWidget list;
+	private OptionListWidget list;
 
 	@SuppressWarnings("resource")
 	public ModMenuOptionsScreen(Screen previous) {
@@ -24,7 +24,7 @@ public class ModMenuOptionsScreen extends GameOptionsScreen {
 
 
 	protected void init() {
-		this.list = new ButtonListWidget(this.client, this.width, this.height, 32, this.height - 32, 25);
+		this.list = new OptionListWidget(this.client, this.width, this.height, 32, this.height - 32, 25);
 		this.list.addAll(ModMenuConfig.asOptions());
 		this.addSelectableChild(this.list);
 		this.addDrawableChild(

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -1,20 +1,18 @@
 package com.terraformersmc.modmenu.gui.widget;
 
-import com.google.common.util.concurrent.Runnables;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import com.terraformersmc.modmenu.gui.widget.entries.ModListEntry;
 import com.terraformersmc.modmenu.util.mod.Mod;
+import net.minecraft.class_8219;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.LogoDrawer;
 import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.screen.ConfirmLinkScreen;
-import net.minecraft.client.gui.screen.CreditsScreen;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.gui.widget.ElementListWidget;
@@ -298,19 +296,14 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		@Override
 		public boolean mouseClicked(double mouseX, double mouseY, int button) {
 			if (isMouseOver(mouseX, mouseY)) {
-				client.setScreen(new MinecraftCredits(false));
+				client.setScreen(new MinecraftCredits());
 			}
 			return super.mouseClicked(mouseX, mouseY, button);
 		}
 
-		class MinecraftCredits extends CreditsScreen {
-			public MinecraftCredits(boolean endCredits) {
-				super(endCredits, new LogoDrawer(false), Runnables.doNothing());
-			}
-
-			@Override
-			public void close() {
-				client.setScreen(parent);
+		class MinecraftCredits extends class_8219 {
+			public MinecraftCredits() {
+				super(parent);
 			}
 		}
 	}


### PR DESCRIPTION
This pull request updates mod to Minecraft 1.19.4 pre-release 4. The bundled Fabric API modules include a fix for the Mod Menu button disappearing when the window is resized, and the 'View Credits' link for the Minecraft mod now links to the newly-introduced attribution screen.