### PR TITLE
Simplify screen background rendering

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
@@ -38,7 +38,7 @@ public class ModMenuOptionsScreen extends GameOptionsScreen {
 
 	@Override
 	public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		this.renderBackground(DrawContext);
+		this.renderBackgroundTexture(DrawContext);
 		this.list.render(DrawContext, mouseX, mouseY, delta);
 		DrawContext.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 5, 0xffffff);
 		super.render(DrawContext, mouseX, mouseY, delta);

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -277,7 +277,7 @@ public class ModsScreen extends Screen {
 
 	@Override
 	public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		this.renderBackground(DrawContext);
+		this.renderBackgroundTexture(DrawContext);
 		ModListEntry selectedEntry = selected;
 		if (selectedEntry != null) {
 			this.descriptionListWidget.render(DrawContext, mouseX, mouseY, delta);
@@ -385,25 +385,6 @@ public class ModsScreen extends Screen {
 			return new int[]{total};
 		}
 		return new int[]{visible, total};
-	}
-
-	@Override
-	public void renderBackground(DrawContext DrawContext) {
-		ModsScreen.overlayBackground(0, 0, this.width, this.height, 64, 64, 64, 255, 255);
-	}
-
-	static void overlayBackground(int x1, int y1, int x2, int y2, int red, int green, int blue, int startAlpha, int endAlpha) {
-		Tessellator tessellator = Tessellator.getInstance();
-		BufferBuilder buffer = tessellator.getBuffer();
-		RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-		RenderSystem.setShaderTexture(0, Screen.OPTIONS_BACKGROUND_TEXTURE);
-		buffer.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-		buffer.vertex(x1, y2, 0.0D).texture(x1 / 32.0F, y2 / 32.0F).color(red, green, blue, endAlpha).next();
-		buffer.vertex(x2, y2, 0.0D).texture(x2 / 32.0F, y2 / 32.0F).color(red, green, blue, endAlpha).next();
-		buffer.vertex(x2, y1, 0.0D).texture(x2 / 32.0F, y1 / 32.0F).color(red, green, blue, startAlpha).next();
-		buffer.vertex(x1, y1, 0.0D).texture(x1 / 32.0F, y1 / 32.0F).color(red, green, blue, startAlpha).next();
-		tessellator.draw();
 	}
 
 	@Override


### PR DESCRIPTION
Hello, I've been experimenting with a an additional optimization in Dynamic FPS recently that modmenu can also benefit from, so I thought I'd PR it here.

The gist of it is that world rendering can be skipped if a screen is covering the whole world, which can be detected by whether a screen has a background. More details: https://github.com/juliand665/Dynamic-FPS/pull/91

Modmenu always has the dirt background, but used its own rendering for it which I've changed in this PR to use the simpler method that can make use of the optimization. Visually there is no difference: [mods screen before](https://files.lostluma.net/gqbiEp.png) [mods screen after](https://files.lostluma.net/r6PtRe.png)