### PR TITLE
Fix update checker not working when no new primary file is found

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/ModrinthUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/ModrinthUtil.java
@@ -81,9 +81,15 @@ public class ModrinthUtil {
 						var projectId = versionObj.get("project_id").getAsString();
 						var versionNumber = versionObj.get("version_number").getAsString();
 						var versionId = versionObj.get("id").getAsString();
-						var versionHash = versionObj.get("files").getAsJsonArray().asList()
-								.stream().filter(file -> file.getAsJsonObject().get("primary").getAsBoolean()).findFirst()
-								.get().getAsJsonObject().get("hashes").getAsJsonObject().get("sha512").getAsString();
+						var primaryFile = versionObj.get("files").getAsJsonArray().asList().stream()
+								.filter(file -> file.getAsJsonObject().get("primary").getAsBoolean()).findFirst();
+
+						if (primaryFile.isEmpty()) {
+							return;
+						}
+
+						var versionHash = primaryFile.get().getAsJsonObject().get("hashes").getAsJsonObject().get("sha512").getAsString();
+
 						if (!Objects.equals(versionHash, lookupHash)) {
 							// hashes different, there's an update.
 							HASH_TO_MOD.get(lookupHash).forEach(mod -> {


### PR DESCRIPTION
Hey, I noticed the update checker will crash when there is no new file marked as a primary file (I'm not sure why this would happen, but it does, apparently). This PR fixes this by ignoring that specific case.

```java
[21:18:24] [Worker-Main-1/ERROR]: Caught exception in thread Thread[#73,Worker-Main-1,5,main]
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:143) ~[?:?]
	at com.terraformersmc.modmenu.util.ModrinthUtil.lambda$checkForUpdates$4(ModrinthUtil.java:86) ~[transformed-mod-modmenu.i0:0/:?]
	at java.util.Map.forEach(Map.java:716) ~[?:?]
	at com.terraformersmc.modmenu.util.ModrinthUtil.lambda$checkForUpdates$5(ModrinthUtil.java:79) ~[transformed-mod-modmenu.i0:0/:?]
	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ~[?:?]
```