### PR TITLE
Fix clicking on a configurable parent mod instantly opening its config

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
@@ -110,10 +110,9 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 				this.openConfig();
 			} else if (Util.getMeasuringTimeMs() - this.sinceLastClick < 250) {
 				this.openConfig();
-			} else {
-				this.sinceLastClick = Util.getMeasuringTimeMs();
 			}
 		}
+		this.sinceLastClick = Util.getMeasuringTimeMs();
 		return true;
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
@@ -66,14 +66,14 @@ public class ParentEntry extends ModListEntry {
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int i) {
 		int iconSize = ModMenuConfig.COMPACT_LIST.getValue() ? COMPACT_ICON_SIZE : FULL_ICON_SIZE;
+		boolean quickConfigure = ModMenuConfig.QUICK_CONFIGURE.getValue();
 		if (mouseX - list.getRowLeft() <= iconSize) {
 			this.toggleChildren();
 			return true;
-		} else if (Util.getMeasuringTimeMs() - this.sinceLastClick < 250) {
+		} else if (!quickConfigure && Util.getMeasuringTimeMs() - this.sinceLastClick < 250) {
 			this.toggleChildren();
 			return true;
 		} else {
-			this.sinceLastClick = Util.getMeasuringTimeMs();
 			return super.mouseClicked(mouseX, mouseY, i);
 		}
 	}


### PR DESCRIPTION
Fixes #596 by only setting the `sinceLastClick` value once.

Since the two double click actions modmenu provides interfere with each other I've also made them exclusive of each other depending on whether quick configure is enabled, but maybe another solution should be thought of:

enabled -> double click on parent mod opens config, little arrow expand child mods
disabled -> double click on parent mod expands child mods (nothing changed here)
