### PR TITLE
Fix version prefixes not being stripped in the update checker message

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import com.terraformersmc.modmenu.gui.widget.entries.ModListEntry;
+import com.terraformersmc.modmenu.util.VersionUtil;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
@@ -86,7 +87,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 						children().add(new DescriptionEntry(Text.translatable("modmenu.hasUpdate").asOrderedText()).setUpdateTextEntry());
 						children().add(new DescriptionEntry(Text.translatable("modmenu.experimental").formatted(Formatting.GOLD).asOrderedText(), 8));
 						children().add(new LinkEntry(
-								Text.translatable("modmenu.updateText", mod.getModrinthData().versionNumber(), Text.translatable("modmenu.modrinth"))
+								Text.translatable("modmenu.updateText", VersionUtil.stripPrefix(mod.getModrinthData().versionNumber()), Text.translatable("modmenu.modrinth"))
 										.formatted(Formatting.BLUE)
 										.formatted(Formatting.UNDERLINE)
 										.asOrderedText(), "https://modrinth.com/project/%s/version/%s".formatted(mod.getModrinthData().projectId(), mod.getModrinthData().versionId()), 8));

--- a/src/main/java/com/terraformersmc/modmenu/util/VersionUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/VersionUtil.java
@@ -1,0 +1,27 @@
+package com.terraformersmc.modmenu.util;
+
+import java.util.List;
+
+public final class VersionUtil {
+	private static final List<String> PREFIXES = List.of("version", "ver", "v");
+
+	private VersionUtil() {
+		return;
+	}
+
+	public static String stripPrefix(String version) {
+		version = version.trim();
+
+		for (String prefix : PREFIXES) {
+			if (version.startsWith(prefix)) {
+				return version.substring(prefix.length());
+			}
+		}
+
+		return version;
+	}
+
+	public static String getPrefixedVersion(String version) {
+		return "v" + stripPrefix(version);
+	}
+}

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -6,6 +6,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.util.OptionalUtil;
+import com.terraformersmc.modmenu.util.VersionUtil;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModrinthData;
 import net.fabricmc.loader.api.FabricLoader;
@@ -190,15 +191,7 @@ public class FabricMod implements Mod {
 	}
 
 	public @NotNull String getPrefixedVersion() {
-		String version = getVersion().trim();
-		if (version.startsWith("version")) {
-			version = "v" + version.substring("version".length());
-		} else if (version.startsWith("ver")) {
-			version = "v" + version.substring("ver".length());
-		} else if (!version.startsWith("v")) {
-			version = "v" + version;
-		}
-		return version.trim();
+		return VersionUtil.getPrefixedVersion(getVersion());
 	}
 
 	@Override


### PR DESCRIPTION
Before | After
--- | ---
<img width="715" alt="Before" src="https://github.com/TerraformersMC/ModMenu/assets/24855774/e2581dbe-9350-425e-8810-5f7dac86793a"> | <img width="717" alt="After" src="https://github.com/TerraformersMC/ModMenu/assets/24855774/c91868ae-c00a-4d14-8e55-1020e52816b3">

Fixes #621