### PR TITLE
Add development environment tag to user agent

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -47,6 +47,7 @@ public class ModMenu implements ClientModInitializer {
 
 	private static int cachedDisplayedModCount = -1;
 	public static boolean runningQuilt = FabricLoader.getInstance().isModLoaded("quilt_loader");
+	public static boolean devEnvironment = FabricLoader.getInstance().isDevelopmentEnvironment();
 
 	public static Screen getConfigScreen(String modid, Screen menuScreen) {
 		if(!delayedScreenFactoryProviders.isEmpty()) {

--- a/src/main/java/com/terraformersmc/modmenu/util/ModrinthUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/ModrinthUtil.java
@@ -50,6 +50,7 @@ public class ModrinthUtil {
 						}
 					});
 
+			String environment = ModMenu.devEnvironment ? "/development": "";
 			String primaryLoader = ModMenu.runningQuilt ? "quilt" : "fabric";
 			List<String> loaders = ModMenu.runningQuilt ? List.of("fabric", "quilt") : List.of("fabric");
 
@@ -57,7 +58,7 @@ public class ModrinthUtil {
 			String[] splitVersion = FabricLoader.getInstance().getModContainer(ModMenu.MOD_ID)
 					.get().getMetadata().getVersion().getFriendlyString().split("\\+", 1); // Strip build metadata for privacy
 			final var modMenuVersion = splitVersion.length > 1 ? splitVersion[1] : splitVersion[0];
-			final var userAgent = "%s/%s (%s/%s)".formatted(ModMenu.GITHUB_REF, modMenuVersion, mcVer, primaryLoader);
+			final var userAgent = "%s/%s (%s/%s%s)".formatted(ModMenu.GITHUB_REF, modMenuVersion, mcVer, primaryLoader, environment);
 			String body = ModMenu.GSON_MINIFIED.toJson(new LatestVersionsFromHashesBody(HASH_TO_MOD.keySet(), loaders, mcVer));
 			LOGGER.debug("User agent: " + userAgent);
 			LOGGER.debug("Body: " + body);


### PR DESCRIPTION
As discussed briefly on Discord two days ago.
Changes the User Agent to `TerraformersMC/ModMenu/7.1.0 (1.20.1/fabric/development)` in dev envs, otherwise leaves it as-is.