### PR TITLE
Hide child libraries when libraries are hidden

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -82,15 +82,15 @@ public class ModMenu implements ClientModInitializer {
 
 		// Fill mods map
 		for (ModContainer modContainer : FabricLoader.getInstance().getAllMods()) {
-			if (!ModMenuConfig.HIDDEN_MODS.getValue().contains(modContainer.getMetadata().getId())) {
-				if (FabricLoader.getInstance().isModLoaded("quilt_loader")) {
-					QuiltMod mod = new QuiltMod(modContainer, modpackMods);
-					MODS.put(mod.getId(), mod);
-				} else {
-					FabricMod mod = new FabricMod(modContainer, modpackMods);
-					MODS.put(mod.getId(), mod);
-				}
+			Mod mod;
+
+			if (runningQuilt) {
+				mod = new QuiltMod(modContainer, modpackMods);
+			} else {
+				mod = new FabricMod(modContainer, modpackMods);
 			}
+
+			MODS.put(mod.getId(), mod);
 		}
 
 		if (ModMenuConfig.UPDATE_CHECKER.getValue()) {
@@ -101,6 +101,9 @@ public class ModMenu implements ClientModInitializer {
 
 		// Initialize parent map
 		for (Mod mod : MODS.values()) {
+			if (mod.isHidden()) {
+				continue;
+			}
 			String parentId = mod.getParent();
 			if (parentId != null) {
 				Mod parent = MODS.getOrDefault(parentId, dummyParents.get(parentId));
@@ -129,7 +132,7 @@ public class ModMenu implements ClientModInitializer {
 			cachedDisplayedModCount = Math.toIntExact(MODS.values().stream().filter(mod ->
 					(ModMenuConfig.COUNT_CHILDREN.getValue() || mod.getParent() == null) &&
 							(ModMenuConfig.COUNT_LIBRARIES.getValue() || !mod.getBadges().contains(Mod.Badge.LIBRARY)) &&
-							(ModMenuConfig.COUNT_HIDDEN_MODS.getValue() || !ModMenuConfig.HIDDEN_MODS.getValue().contains(mod.getId()))
+							(ModMenuConfig.COUNT_HIDDEN_MODS.getValue() || !mod.isHidden())
 			).count());
 		}
 		return NumberFormat.getInstance().format(cachedDisplayedModCount);

--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -101,9 +101,6 @@ public class ModMenu implements ClientModInitializer {
 
 		// Initialize parent map
 		for (Mod mod : MODS.values()) {
-			if (mod.isHidden()) {
-				continue;
-			}
 			String parentId = mod.getParent();
 			if (parentId != null) {
 				Mod parent = MODS.getOrDefault(parentId, dummyParents.get(parentId));

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -359,10 +359,10 @@ public class ModsScreen extends Screen {
 	}
 
 	private Text computeModCountText(boolean includeLibs) {
-		int[] rootMods = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> !mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
+		int[] rootMods = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> !mod.isHidden() && !mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
 
 		if (includeLibs && ModMenuConfig.SHOW_LIBRARIES.getValue()) {
-			int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
+			int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
 			return TranslationUtil.translateNumeric("modmenu.showingModsLibraries", rootMods, rootLibs);
 		} else {
 			return TranslationUtil.translateNumeric("modmenu.showingMods", rootMods);
@@ -371,7 +371,7 @@ public class ModsScreen extends Screen {
 
 	private Text computeLibraryCountText() {
 		if (ModMenuConfig.SHOW_LIBRARIES.getValue()) {
-			int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
+			int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values().stream().filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY)).map(Mod::getId).collect(Collectors.toSet()));
 			return TranslationUtil.translateNumeric("modmenu.showingLibraries", rootLibs);
 		} else {
 			return Text.literal(null);

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -118,6 +118,16 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 		filter(searchTerm, refresh, true);
 	}
 
+	private boolean hasVisibleChildMods(Mod parent) {
+		// All child mods shown, skip further checks
+		if (ModMenuConfig.SHOW_LIBRARIES.getValue()) {
+			return true;
+		}
+
+		List<Mod> children = ModMenu.PARENT_MAP.get(parent);
+		return !children.stream().allMatch(child -> child.getBadges().contains(Mod.Badge.LIBRARY));
+	}
+
 	private void filter(String searchTerm, boolean refresh, boolean search) {
 		this.clearEntries();
 		addedMods.clear();
@@ -129,6 +139,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 					return false;
 				}
 			}
+
 			return !mod.isHidden();
 		}).collect(Collectors.toSet());
 
@@ -154,7 +165,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 			}
 
 			if (!ModMenu.PARENT_MAP.values().contains(mod)) {
-				if (ModMenu.PARENT_MAP.keySet().contains(mod)) {
+				if (ModMenu.PARENT_MAP.keySet().contains(mod) && hasVisibleChildMods(mod)) {
 					//Add parent mods when not searching
 					List<Mod> children = ModMenu.PARENT_MAP.get(mod);
 					children.sort(ModMenuConfig.SORTING.getValue().getComparator());

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -129,7 +129,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 					return false;
 				}
 			}
-			return !ModMenuConfig.HIDDEN_MODS.getValue().contains(mod.getId());
+			return !mod.isHidden();
 		}).collect(Collectors.toSet());
 
 		if (DEBUG) {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -114,6 +114,8 @@ public interface Mod {
 
 	boolean getChildHasUpdate();
 
+	boolean isHidden();
+
 	enum Badge {
 		LIBRARY("modmenu.badge.library", 0xff107454, 0xff093929, "library"),
 		CLIENT("modmenu.badge.clientsideOnly", 0xff2b4b7c, 0xff0e2a55, null),

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
@@ -1,6 +1,7 @@
 package com.terraformersmc.modmenu.util.mod;
 
 import com.terraformersmc.modmenu.ModMenu;
+import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.Pair;
@@ -42,6 +43,11 @@ public class ModSearch {
 		String deprecated = I18n.translate("modmenu.searchTerms.deprecated");
 		String clientside = I18n.translate("modmenu.searchTerms.clientside");
 		String configurable = I18n.translate("modmenu.searchTerms.configurable");
+
+		// Libraries are currently hidden, ignore them entirely
+		if (!ModMenuConfig.SHOW_LIBRARIES.getValue() && mod.getBadges().contains(Mod.Badge.LIBRARY)) {
+			return 0;
+		}
 
 		// Some basic search, could do with something more advanced but this will do for now
 		if (modName.toLowerCase(Locale.ROOT).contains(query) // Search default mod name

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
@@ -1,6 +1,7 @@
 package com.terraformersmc.modmenu.util.mod.fabric;
 
 import com.terraformersmc.modmenu.ModMenu;
+import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModrinthData;
 import net.fabricmc.loader.api.FabricLoader;
@@ -178,5 +179,10 @@ public class FabricDummyParentMod implements Mod {
 	@Override
 	public void setChildHasUpdate() {
 		this.childHasUpdate = true;
+	}
+
+	@Override
+	public boolean isHidden() {
+		return ModMenuConfig.HIDDEN_MODS.getValue().contains(this.getId());
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -44,8 +44,6 @@ public class FabricMod implements Mod {
 
 	protected boolean childHasUpdate = false;
 
-	protected boolean hidesItself = false;
-
 	public FabricMod(ModContainer modContainer, Set<String> modpackMods) {
 		this.container = modContainer;
 		this.metadata = modContainer.getMetadata();
@@ -89,7 +87,6 @@ public class FabricMod implements Mod {
 			badgeNames.addAll(CustomValueUtil.getStringSet("badges", modMenuObject).orElse(new HashSet<>()));
 			links.putAll(CustomValueUtil.getStringMap("links", modMenuObject).orElse(new HashMap<>()));
 			allowsUpdateChecks = CustomValueUtil.getBoolean("update_checker", modMenuObject).orElse(true);
-			hidesItself = CustomValueUtil.getBoolean("hidden", modMenuObject).orElse(false);
 		}
 		this.modMenuData = new ModMenuData(
 				badgeNames,
@@ -335,7 +332,7 @@ public class FabricMod implements Mod {
 
 	@Override
 	public boolean isHidden() {
-		return this.hidesItself || ModMenuConfig.HIDDEN_MODS.getValue().contains(this.getId());
+		return ModMenuConfig.HIDDEN_MODS.getValue().contains(this.getId());
 	}
 
 	static class ModMenuData {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.terraformersmc.modmenu.ModMenu;
+import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.OptionalUtil;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModrinthData;
@@ -42,6 +43,8 @@ public class FabricMod implements Mod {
 	protected boolean allowsUpdateChecks = true;
 
 	protected boolean childHasUpdate = false;
+
+	protected boolean hidesItself = false;
 
 	public FabricMod(ModContainer modContainer, Set<String> modpackMods) {
 		this.container = modContainer;
@@ -86,6 +89,7 @@ public class FabricMod implements Mod {
 			badgeNames.addAll(CustomValueUtil.getStringSet("badges", modMenuObject).orElse(new HashSet<>()));
 			links.putAll(CustomValueUtil.getStringMap("links", modMenuObject).orElse(new HashMap<>()));
 			allowsUpdateChecks = CustomValueUtil.getBoolean("update_checker", modMenuObject).orElse(true);
+			hidesItself = CustomValueUtil.getBoolean("hidden", modMenuObject).orElse(false);
 		}
 		this.modMenuData = new ModMenuData(
 				badgeNames,
@@ -327,6 +331,11 @@ public class FabricMod implements Mod {
 	@Override
 	public void setChildHasUpdate() {
 		this.childHasUpdate = true;
+	}
+
+	@Override
+	public boolean isHidden() {
+		return this.hidesItself || ModMenuConfig.HIDDEN_MODS.getValue().contains(this.getId());
 	}
 
 	static class ModMenuData {


### PR DESCRIPTION
Allows mods to hide themselves via mod metadata.

I've had this idea floating in my head for a while, as the child mod counter obscures a large part of the mod icon on compact mode, and child mods are most times more of an implementation detail rather than part of the surface I'd want users to interact with. There is probably other reasons to do this as well though.

This is especially apparent with my upcoming mod's icon, see the [before](https://files.lostluma.net/tjO0Ge.png) and [after](https://files.lostluma.net/G38ypS.png) comparison. (I'm not really interested in simply having it display as a non-child mod as a workaround, fwiw)