### PR TITLE
Display mod description below shadows

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -161,6 +161,10 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			tessellator.draw();
 		}
 
+		this.enableScissor(DrawContext);
+		this.renderList(DrawContext, mouseX, mouseY, delta);
+		DrawContext.disableScissor();
+
 		RenderSystem.depthFunc(515);
 		RenderSystem.disableDepthTest();
 		RenderSystem.enableBlend();
@@ -209,10 +213,6 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 				next();
 		tessellator.draw();
-
-		this.enableScissor(DrawContext);
-		this.renderList(DrawContext, mouseX, mouseY, delta);
-		DrawContext.disableScissor();
 
 		this.renderScrollBar(bufferBuilder, tessellator);
 


### PR DESCRIPTION
The mod list already do that so it seams it is a bug.

Before / After :

![image](https://github.com/TerraformersMC/ModMenu/assets/51191602/5c0709da-32ef-44b4-bccb-7e70c78ac35c)
