### PR TITLE
add error message for nonsquare mod icons

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricIconHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricIconHandler.java
@@ -39,6 +39,12 @@ public class FabricIconHandler implements Closeable {
 				return tex;
 			}
 
+		} catch (IllegalStateException e) {
+			if (e.getMessage().equals("Must be square icon")) {
+				LOGGER.error("Mod icon must be a square for icon source {}: {}", iconSource.getMetadata().getId(), iconPath, e);
+			}
+
+			return null;
 		} catch (Throwable t) {
 			if (!iconPath.equals("assets/" + iconSource.getMetadata().getId() + "/icon.png")) {
 				LOGGER.error("Invalid mod icon for icon source {}: {}", iconSource.getMetadata().getId(), iconPath, t);


### PR DESCRIPTION
Currently ModMenu doesn't provide a clear error message for when a mod provides a non-square mod icon, just indicating it's a broken icon. This PR should indicate that the icon is not square to the log for mod developers to more easily pinpoint this issue.