### PR TITLE
Update mod to Minecraft snapshot 23w31a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.2
-loader_version=0.14.21
-fabric_version=0.83.1+1.20.1
+minecraft_version=23w31a
+yarn_mappings=23w31a+build.12
+loader_version=0.14.22
+fabric_version=0.86.1+1.20.2
 quilt_loader_version=0.17.7
 
 # Project Metadata

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
@@ -38,10 +38,14 @@ public class ModMenuOptionsScreen extends GameOptionsScreen {
 
 	@Override
 	public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		this.renderBackgroundTexture(DrawContext);
+		super.render(DrawContext, mouseX, mouseY, delta);
 		this.list.render(DrawContext, mouseX, mouseY, delta);
 		DrawContext.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 5, 0xffffff);
-		super.render(DrawContext, mouseX, mouseY, delta);
+	}
+
+	@Override
+	public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
+		this.renderBackgroundTexture(context);
 	}
 
 	public void removed() {

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -6,6 +6,7 @@ import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.config.ModMenuConfigManager;
 import com.terraformersmc.modmenu.gui.widget.DescriptionListWidget;
+import com.terraformersmc.modmenu.gui.widget.LegacyTexturedButtonWidget;
 import com.terraformersmc.modmenu.gui.widget.ModListWidget;
 import com.terraformersmc.modmenu.gui.widget.entries.ModListEntry;
 import com.terraformersmc.modmenu.util.DrawingUtil;
@@ -19,7 +20,6 @@ import net.minecraft.client.gui.screen.ConfirmScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.client.gui.widget.TexturedButtonWidget;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.render.*;
 import net.minecraft.client.resource.language.I18n;
@@ -79,19 +79,14 @@ public class ModsScreen extends Screen {
 	}
 
 	@Override
-	public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
+	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
 		if (modList.isMouseOver(mouseX, mouseY)) {
-			return this.modList.mouseScrolled(mouseX, mouseY, amount);
+			return this.modList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
 		}
 		if (descriptionListWidget.isMouseOver(mouseX, mouseY)) {
-			return this.descriptionListWidget.mouseScrolled(mouseX, mouseY, amount);
+			return this.descriptionListWidget.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
 		}
 		return false;
-	}
-
-	@Override
-	public void tick() {
-		this.searchBox.tick();
 	}
 
 	@Override
@@ -131,7 +126,7 @@ public class ModsScreen extends Screen {
 
 		this.descriptionListWidget = new DescriptionListWidget(this.client, paneWidth, this.height, RIGHT_PANE_Y + 60, this.height - 36, textRenderer.fontHeight + 1, this);
 		this.descriptionListWidget.setLeftPos(rightPaneX);
-		ButtonWidget configureButton = new TexturedButtonWidget(width - 24, RIGHT_PANE_Y, 20, 20, 0, 0, 20, CONFIGURE_BUTTON_LOCATION, 32, 64, button -> {
+		ButtonWidget configureButton = new LegacyTexturedButtonWidget(width - 24, RIGHT_PANE_Y, 20, 20, 0, 0, 20, CONFIGURE_BUTTON_LOCATION, 32, 64, button -> {
 			final String id = Objects.requireNonNull(selected).getMod().getId();
 			if (modHasConfigScreen.get(id)) {
 				Screen configScreen = ModMenu.getConfigScreen(id, this);
@@ -203,7 +198,7 @@ public class ModsScreen extends Screen {
 			}
 		};
 		this.addSelectableChild(this.searchBox);
-		ButtonWidget filtersButton = new TexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, 20, FILTERS_BUTTON_LOCATION, 32, 64, button -> filterOptionsShown = !filterOptionsShown, TOGGLE_FILTER_OPTIONS);
+		ButtonWidget filtersButton = new LegacyTexturedButtonWidget(paneWidth / 2 + searchBoxWidth / 2 - 20 / 2 + 2, 22, 20, 20, 0, 0, 20, FILTERS_BUTTON_LOCATION, 32, 64, button -> filterOptionsShown = !filterOptionsShown, TOGGLE_FILTER_OPTIONS);
 		filtersButton.setTooltip(Tooltip.of(TOGGLE_FILTER_OPTIONS));
 		if (!ModMenuConfig.CONFIG_MODE.getValue()) {
 			this.addDrawableChild(filtersButton);
@@ -277,7 +272,7 @@ public class ModsScreen extends Screen {
 
 	@Override
 	public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		this.renderBackgroundTexture(DrawContext);
+		super.render(DrawContext, mouseX, mouseY, delta);
 		ModListEntry selectedEntry = selected;
 		if (selectedEntry != null) {
 			this.descriptionListWidget.render(DrawContext, mouseX, mouseY, delta);
@@ -355,7 +350,11 @@ public class ModsScreen extends Screen {
 				DrawingUtil.drawWrappedString(DrawContext, I18n.translate("modmenu.authorPrefix", authors), x + imageOffset, RIGHT_PANE_Y + 2 + lineSpacing * 2, paneWidth - imageOffset - 4, 1, 0x808080);
 			}
 		}
-		super.render(DrawContext, mouseX, mouseY, delta);
+	}
+
+	@Override
+	public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
+		this.renderBackgroundTexture(context);
 	}
 
 	private Text computeModCountText(boolean includeLibs) {

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/LegacyTexturedButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/LegacyTexturedButtonWidget.java
@@ -1,0 +1,52 @@
+package com.terraformersmc.modmenu.gui.widget;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ButtonTextures;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.TexturedButtonWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class LegacyTexturedButtonWidget extends TexturedButtonWidget {
+	private final int u;
+	private final int v;
+	private final int hoveredVOffset;
+
+	private final Identifier texture;
+
+	private final int textureWidth;
+	private final int textureHeight;
+
+	public LegacyTexturedButtonWidget(int x, int y, int width, int height, int u, int v, int hoveredVOffset, Identifier texture, int textureWidth, int textureHeight, ButtonWidget.PressAction pressAction) {
+		this(x, y, width, height, u, v, hoveredVOffset, texture, textureWidth, textureHeight, pressAction, ScreenTexts.EMPTY);
+	}
+
+	public LegacyTexturedButtonWidget(int x, int y, int width, int height, int u, int v, int hoveredVOffset, Identifier texture, int textureWidth, int textureHeight, ButtonWidget.PressAction pressAction, Text message) {
+		super(x, y, width, height, null, pressAction, message);
+
+		this.u = u;
+		this.v = v;
+		this.hoveredVOffset = hoveredVOffset;
+
+		this.texture = texture;
+
+		this.textureWidth = textureWidth;
+		this.textureHeight = textureHeight;
+	}
+
+	@Override
+	public void renderButton(DrawContext context, int mouseX, int mouseY, float delta) {
+		int v = this.v;
+
+		if (!this.isNarratable()) {
+			v += this.hoveredVOffset * 2;
+		} else if (this.isSelected()) {
+			v += this.hoveredVOffset;
+		}
+
+		context.drawTexture(this.texture, this.getX(), this.getY(), this.u, v, this.width, this.height, this.textureWidth, this.textureHeight);
+	}
+}

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
@@ -7,7 +7,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
 public class UpdateAvailableBadge {
-	private static final Identifier UPDATE_ICON = new Identifier("realms", "textures/gui/realms/trial_icon.png");
+	private static final Identifier UPDATE_ICON = new Identifier("icon/trial_available");
 
 	public static void renderBadge(DrawContext DrawContext, int x, int y) {
 		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
@@ -15,6 +15,6 @@ public class UpdateAvailableBadge {
 		if ((Util.getMeasuringTimeMs() / 800L & 1L) == 1L) {
 			animOffset = 8;
 		}
-		DrawContext.drawTexture(UPDATE_ICON, x, y, 0f, animOffset, 8, 8, 8, 16);
+		DrawContext.drawGuiTexture(UPDATE_ICON, x, y, 8, 8);
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateCheckerTexturedButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateCheckerTexturedButtonWidget.java
@@ -5,12 +5,11 @@ import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.TexturedButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
-public class UpdateCheckerTexturedButtonWidget extends TexturedButtonWidget {
+public class UpdateCheckerTexturedButtonWidget extends LegacyTexturedButtonWidget {
 	public UpdateCheckerTexturedButtonWidget(int x, int y, int width, int height, int u, int v, int hoveredVOffset, Identifier texture, int textureWidth, int textureHeight, ButtonWidget.PressAction pressAction, Text message) {
 		super(x, y, width, height, u, v, hoveredVOffset, texture, textureWidth, textureHeight, pressAction, message);
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
     "fabric-key-binding-api-v1": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabricloader": ">=0.12.13",
-    "minecraft": ">=1.19.4-"
+    "minecraft": ">=1.20.2-"
   },
   "breaks" : {
     "better_mod_button": "*"


### PR DESCRIPTION
This pull request updates the mod to Minecraft snapshot 23w31a, which contains significant changes to how screens and sprites are rendered. This pull request should be merged into a new `1.20.2` branch.

Screens are affected by a small refactor, where the `super.render` call is placed first and the `this.renderBackgroundTexture` call is replaced by an override of the `renderBackground` method:

```diff
  @Override
  public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
- 	this.renderBackgroundTexture(DrawContext);
+ 	super.render(DrawContext, mouseX, mouseY, delta);
  
  	// Additional code
  
- 	super.render(DrawContext, mouseX, mouseY, delta);
  }
+ 
+ @Override
+ public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
+ 	this.renderBackgroundTexture(context);
+ }
```

The most significant change in Minecraft snapshot 23w31a is that sprites are now part of an atlas. This pull request does not follow this change to preserve resource pack compatibility, though the change could still happen in the future.

Due to [a vanilla bug](https://bugs.mojang.com/browse/MC-264917), the mod list does not render shadow gradients properly above mod entries.

This mod version also works with Minecraft snapshots 23w32a and 23w33a if a newer Fabric API version than the bundled version is installed.