### PR TITLE
Update mod to Minecraft snapshot 23w42a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=23w40a
-yarn_mappings=23w40a+build.9
+minecraft_version=23w41a
+yarn_mappings=23w41a+build.6
 loader_version=0.14.23
-fabric_version=0.90.0+1.20.3
+fabric_version=0.90.1+1.20.3
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,7 +20,7 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=23w40a
+modrinth_game_versions=23w41a
 modrinth_mod_loaders=fabric, quilt
 
 # Mod Loader Metadata

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=23w41a
-yarn_mappings=23w41a+build.6
+minecraft_version=23w42a
+yarn_mappings=23w42a+build.1
 loader_version=0.14.23
-fabric_version=0.90.1+1.20.3
+fabric_version=0.90.3+1.20.3
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,7 +20,7 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=23w41a
+modrinth_game_versions=23w42a
 modrinth_mod_loaders=fabric, quilt
 
 # Mod Loader Metadata

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.1
-loader_version=0.14.22
-fabric_version=0.89.2+1.20.2
+minecraft_version=23w40a
+yarn_mappings=23w40a+build.9
+loader_version=0.14.23
+fabric_version=0.90.0+1.20.3
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,7 +20,7 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.2
+modrinth_game_versions=23w40a
 modrinth_mod_loaders=fabric, quilt
 
 # Mod Loader Metadata

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -266,8 +266,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 					this.setDragging(true);
 					return true;
 				}
-			} else if (int_1 == 0) {
-				this.clickedHeader((int) (double_1 - (double) (this.left + this.width / 2 - this.getRowWidth() / 2)), (int) (double_2 - (double) this.top) + (int) this.getScrollAmount() - 4);
+			} else if (int_1 == 0 && this.clickedHeader((int) (double_1 - (double) (this.left + this.width / 2 - this.getRowWidth() / 2)), (int) (double_2 - (double) this.top) + (int) this.getScrollAmount() - 4)) {
 				return true;
 			}
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
     "fabric-screen-api-v1": ">=1.0.4",
     "fabric-key-binding-api-v1": "*",
     "fabric-lifecycle-events-v1": "*",
-    "fabricloader": ">=0.12.13",
-    "minecraft": ">=1.20.2-"
+    "fabricloader": ">=0.12.23",
+    "minecraft": ">=1.20.3-"
   },
   "breaks" : {
     "better_mod_button": "*"


### PR DESCRIPTION
This pull request updates the mod to Minecraft snapshot 23w42a by changing header click behavior to follow an equivalent change in the `EntryListWidget` class and a different return type for the `EntryListWidget#clickedHeader` method. This pull request should be merged into a new `1.20.3` branch.

Since this version does not support Minecraft 1.20.2, the dependency has been updated accordingly. The Fabric loader dependency has also been updated to require version 0.14.23 or later, which supports snapshot versions for Minecraft 1.20.3.