### PR TITLE
Update mod to Minecraft 1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.3-pre4
-yarn_mappings=1.20.3-pre4+build.2
-loader_version=0.14.25
-fabric_version=0.91.1+1.20.3
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.2
+loader_version=0.15.1
+fabric_version=0.91.2+1.20.4
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,7 +20,7 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.3-pre4
+modrinth_game_versions=1.20.3-pre4, 1.20.3-rc1, 1.20.3, 1.20.4-rc1, 1.20.4
 modrinth_mod_loaders=fabric, quilt
 
 # Mod Loader Metadata


### PR DESCRIPTION
This pull request only updates the values in `gradle.properties`, as [version 9.0.0 pre-release 1](https://github.com/TerraformersMC/ModMenu/releases/tag/v9.0.0-pre.1) already works on Minecraft 1.20.3 pre-release 4 through Minecraft 1.20.4. However, #680 can also be merged along with this pull request.