### PR TITLE
Fix disable update checks config not working for individual mods

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -283,7 +283,11 @@ public class FabricMod implements Mod {
 
 	@Override
 	public boolean allowsUpdateChecks() {
-		return this.allowsUpdateChecks || ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue().contains(this.getId());
+		if (ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue().contains(this.getId())) {
+			return false;
+		}
+
+		return this.allowsUpdateChecks;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes logic error that prevented the `disable_update_checker` config option from taking effect in the update checker.
This fixes the issue reported by `@boar420` on Discord where the indicator in the main menu still shows despite using this option.