### PR TITLE
Add option to choose which update channel to receive notifications for

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -99,7 +99,7 @@ public class ModMenu implements ClientModInitializer {
 			MODS.put(mod.getId(), mod);
 		}
 
-		UpdateCheckerUtil.checkForUpdates();
+		checkForUpdates();
 
 		Map<String, Mod> dummyParents = new HashMap<>();
 
@@ -125,6 +125,10 @@ public class ModMenu implements ClientModInitializer {
 
 	public static void clearModCountCache() {
 		cachedDisplayedModCount = -1;
+	}
+
+	public static void checkForUpdates() {
+		UpdateCheckerUtil.checkForUpdates();
 	}
 
 	public static boolean areModUpdatesAvailable() {

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
@@ -1,10 +1,19 @@
 package com.terraformersmc.modmenu.api;
 
+import com.terraformersmc.modmenu.config.ModMenuConfig;
+
 /**
  * Supported update channels, in ascending order by stability.
  */
 public enum UpdateChannel {
 	ALPHA,
 	BETA,
-	RELEASE,
+	RELEASE;
+
+	/**
+	 * @return the user's preferred update channel.
+	 */
+	public UpdateChannel getUserPreference() {
+		return ModMenuConfig.UPDATE_CHANNEL.getValue();
+	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
@@ -1,0 +1,7 @@
+package com.terraformersmc.modmenu.api;
+
+public enum UpdateChannel {
+	ALPHA,
+	BETA,
+	RELEASE,
+}

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
@@ -13,7 +13,7 @@ public enum UpdateChannel {
 	/**
 	 * @return the user's preferred update channel.
 	 */
-	public UpdateChannel getUserPreference() {
+	public static UpdateChannel getUserPreference() {
 		return ModMenuConfig.UPDATE_CHANNEL.getValue();
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChannel.java
@@ -1,5 +1,8 @@
 package com.terraformersmc.modmenu.api;
 
+/**
+ * Supported update channels, in ascending order by stability.
+ */
 public enum UpdateChannel {
 	ALPHA,
 	BETA,

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
@@ -5,10 +5,9 @@ public interface UpdateChecker {
 	 * Gets called when ModMenu is checking for updates.
 	 * This is done in a separate thread, so this call can/should be blocking.
 	 *
-	 * Your update checker should aim to return an update on the same or a more stable channel than requested.
+	 * <p>Your update checker should aim to return an update on the same or a more stable channel than the user's preference which you can get via {@link UpdateChannel#getUserPreference()}.</p>
 	 *
-	 * @param updateChannel The end user's preferred update channel.
 	 * @return The update info
 	 */
-	UpdateInfo checkForUpdates(UpdateChannel updateChannel);
+	UpdateInfo checkForUpdates();
 }

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
@@ -1,13 +1,14 @@
 package com.terraformersmc.modmenu.api;
 
 public interface UpdateChecker {
-
 	/**
 	 * Gets called when ModMenu is checking for updates.
 	 * This is done in a separate thread, so this call can/should be blocking.
 	 *
+	 * Your update checker should aim to return an update on the same or a more stable channel than requested.
+	 *
+	 * @param updateChannel The end user's preferred update channel.
 	 * @return The update info
 	 */
-	UpdateInfo checkForUpdates();
-
+	UpdateInfo checkForUpdates(UpdateChannel updateChannel);
 }

--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateInfo.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateInfo.java
@@ -4,7 +4,6 @@ import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
 public interface UpdateInfo {
-
 	/**
 	 * @return If an update for the mod is available.
 	 */
@@ -23,4 +22,8 @@ public interface UpdateInfo {
 	 */
 	String getDownloadLink();
 
+	/**
+	 * @return The update channel this update is available for.
+	 */
+	UpdateChannel getUpdateChannel();
 }

--- a/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
@@ -1,6 +1,7 @@
 package com.terraformersmc.modmenu.config;
 
 import com.google.gson.annotations.SerializedName;
+import com.terraformersmc.modmenu.api.UpdateChannel;
 import com.terraformersmc.modmenu.config.option.BooleanConfigOption;
 import com.terraformersmc.modmenu.config.option.EnumConfigOption;
 import com.terraformersmc.modmenu.config.option.OptionConvertable;
@@ -44,6 +45,7 @@ public class ModMenuConfig {
 	public static final BooleanConfigOption UPDATE_CHECKER = new BooleanConfigOption("update_checker", true);
 	public static final BooleanConfigOption BUTTON_UPDATE_BADGE = new BooleanConfigOption("button_update_badge", true);
 	public static final BooleanConfigOption QUICK_CONFIGURE = new BooleanConfigOption("quick_configure", true);
+	public static final EnumConfigOption<UpdateChannel> UPDATE_CHANNEL = new EnumConfigOption<>("update_channel", UpdateChannel.RELEASE);
 
 	public static SimpleOption<?>[] asOptions() {
 		ArrayList<SimpleOption<?>> options = new ArrayList<>();

--- a/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
@@ -44,8 +44,8 @@ public class ModMenuConfig {
 	public static final StringSetConfigOption DISABLE_UPDATE_CHECKER = new StringSetConfigOption("disable_update_checker", new HashSet<>());
 	public static final BooleanConfigOption UPDATE_CHECKER = new BooleanConfigOption("update_checker", true);
 	public static final BooleanConfigOption BUTTON_UPDATE_BADGE = new BooleanConfigOption("button_update_badge", true);
-	public static final BooleanConfigOption QUICK_CONFIGURE = new BooleanConfigOption("quick_configure", true);
 	public static final EnumConfigOption<UpdateChannel> UPDATE_CHANNEL = new EnumConfigOption<>("update_channel", UpdateChannel.RELEASE);
+	public static final BooleanConfigOption QUICK_CONFIGURE = new BooleanConfigOption("quick_configure", true);
 
 	public static SimpleOption<?>[] asOptions() {
 		ArrayList<SimpleOption<?>> options = new ArrayList<>();

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
@@ -1,5 +1,6 @@
 package com.terraformersmc.modmenu.gui;
 
+import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.config.ModMenuConfigManager;
 import net.minecraft.client.MinecraftClient;
@@ -29,6 +30,7 @@ public class ModMenuOptionsScreen extends GameOptionsScreen {
 		this.addSelectableChild(this.list);
 		this.addDrawableChild(
 				ButtonWidget.builder(ScreenTexts.DONE, (button) -> {
+							ModMenu.checkForUpdates();
 							ModMenuConfigManager.save();
 							this.client.setScreen(this.previous);
 						}).position(this.width / 2 - 100, this.height - 27)

--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -46,12 +46,14 @@ public class UpdateCheckerUtil {
 	}
 
 	public static void checkForCustomUpdates() {
+		UpdateChannel preferredChannel = ModMenuConfig.UPDATE_CHANNEL.getValue();
+
 		ModMenu.MODS.values().stream().filter(UpdateCheckerUtil::allowsUpdateChecks).forEach(mod -> {
 			UpdateChecker updateChecker = mod.getUpdateChecker();
 			if (updateChecker == null) {
 				return;
 			}
-			UpdateCheckerThread.run(mod, () -> mod.setUpdateInfo(updateChecker.checkForUpdates()));
+			UpdateCheckerThread.run(mod, () -> mod.setUpdateInfo(updateChecker.checkForUpdates(preferredChannel)));
 		});
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -46,14 +46,12 @@ public class UpdateCheckerUtil {
 	}
 
 	public static void checkForCustomUpdates() {
-		UpdateChannel preferredChannel = ModMenuConfig.UPDATE_CHANNEL.getValue();
-
 		ModMenu.MODS.values().stream().filter(UpdateCheckerUtil::allowsUpdateChecks).forEach(mod -> {
 			UpdateChecker updateChecker = mod.getUpdateChecker();
 			if (updateChecker == null) {
 				return;
 			}
-			UpdateCheckerThread.run(mod, () -> mod.setUpdateInfo(updateChecker.checkForUpdates(preferredChannel)));
+			UpdateCheckerThread.run(mod, () -> mod.setUpdateInfo(updateChecker.checkForUpdates()));
 		});
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -114,7 +114,8 @@ public interface Mod {
 		if (updateInfo == null) {
 			return false;
 		}
-		return updateInfo.isUpdateAvailable();
+
+		return updateInfo.isUpdateAvailable() && updateInfo.getUpdateChannel().compareTo(ModMenuConfig.UPDATE_CHANNEL.getValue()) >= 0;
 	}
 
 	default @Nullable String getSha512Hash() throws IOException {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModrinthUpdateInfo.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModrinthUpdateInfo.java
@@ -1,17 +1,19 @@
 package com.terraformersmc.modmenu.util.mod;
 
+import com.terraformersmc.modmenu.api.UpdateChannel;
 import com.terraformersmc.modmenu.api.UpdateInfo;
 
 public class ModrinthUpdateInfo implements UpdateInfo {
+	protected final String projectId;
+	protected final String versionId;
+	protected final String versionNumber;
+	protected final UpdateChannel updateChannel;
 
-	protected String projectId;
-	protected String versionId;
-	protected String versionNumber;
-
-	public ModrinthUpdateInfo(String projectId, String versionId, String versionNumber) {
+	public ModrinthUpdateInfo(String projectId, String versionId, String versionNumber, UpdateChannel updateChannel) {
 		this.projectId = projectId;
 		this.versionId = versionId;
 		this.versionNumber = versionNumber;
+		this.updateChannel = updateChannel;
 	}
 
 	@Override
@@ -36,4 +38,8 @@ public class ModrinthUpdateInfo implements UpdateInfo {
 		return versionNumber;
 	}
 
+	@Override
+	public UpdateChannel getUpdateChannel() {
+		return this.updateChannel;
+	}
 }

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -164,5 +164,9 @@
   "option.modmenu.button_update_badge.false": "Hidden",
   "option.modmenu.quick_configure": "Quick Configure",
   "option.modmenu.quick_configure.true": "Enabled",
-  "option.modmenu.quick_configure.false": "Disabled"
+  "option.modmenu.quick_configure.false": "Disabled",
+  "option.modmenu.update_channel": "Update Channel",
+  "option.modmenu.update_channel.alpha": "All",
+  "option.modmenu.update_channel.beta": "Release & Beta",
+  "option.modmenu.update_channel.release": "Release"
 }


### PR DESCRIPTION
Fixes #604 by allowing the user to choose between receiving all updates, betas and releases, or only releases (default).
This branch is based on the work from #679 and I will keep this as a draft until Max's work is merged into the upstream repo.

It'd however be awesome if these two PRs could land in the same release of ModMenu so I do not have to mark the new method in the `UpdateInfo` interface as being optional (and prob end up not being used a lot).