### PR TITLE
Group mod credits by role instead of bunching them together

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -221,11 +221,11 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 								int indent = 8;
 
 								var role = iterator.next();
-								var rolename = role.getKey();
+								var roleName = role.getKey();
 
-								var name = Text.translatableWithFallback("modmenu.credits.role." + rolename.toLowerCase(), rolename);
+								var component = Text.translatableWithFallback("modmenu.credits.role." + roleName.toLowerCase(), roleName);
 
-								for (var line : textRenderer.wrapLines(name.append(Text.literal(":")), wrapWidth - 16)) {
+								for (var line : textRenderer.wrapLines(component.append(Text.literal(":")), wrapWidth - 16)) {
 									children().add(new DescriptionEntry(line, indent));
 									indent = 16;
 								}

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -223,9 +223,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 								var role = iterator.next();
 								var roleName = role.getKey();
 
-								var component = Text.translatableWithFallback("modmenu.credits.role." + roleName.toLowerCase(), roleName);
-
-								for (var line : textRenderer.wrapLines(component.append(Text.literal(":")), wrapWidth - 16)) {
+								for (var line : textRenderer.wrapLines(this.creditsRoleText(roleName), wrapWidth - 16)) {
 									children().add(new DescriptionEntry(line, indent));
 									indent = 16;
 								}
@@ -350,6 +348,18 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			bufferBuilder.vertex(scrollbarStartX, q, 0.0D).color(192, 192, 192, 255).next();
 			tessellator.draw();
 		}
+	}
+
+	private Text creditsRoleText(String roleName) {
+		// Replace spaces and dashes in role names with underscores if they exist
+		// Notably Quilted Fabric API does this with FabricMC as "Upstream Owner"
+		var translationKey = roleName.replaceAll("[\s-]", "_");
+
+		// Add an s to the default untranslated string if it ends in r since this
+		// Fixes common role names people use in English (e.g. Author -> Authors)
+		var fallback = roleName.endsWith("r") ? roleName + "s" : roleName;
+
+		return Text.translatableWithFallback("modmenu.credits.role." + translationKey, fallback).append(Text.literal(":"));
 	}
 
 	protected class DescriptionEntry extends ElementListWidget.Entry<DescriptionEntry> {

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -219,9 +219,13 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 							while (iterator.hasNext()) {
 								int indent = 8;
-								var role = iterator.next();
 
-								for (var line : textRenderer.wrapLines(Text.literal(role.getKey() + ":"), wrapWidth - 16)) {
+								var role = iterator.next();
+								var rolename = role.getKey();
+
+								var name = Text.translatableWithFallback("modmenu.credits.role." + rolename.toLowerCase(), rolename);
+
+								for (var line : textRenderer.wrapLines(name.append(Text.literal(":")), wrapWidth - 16)) {
 									children().add(new DescriptionEntry(line, indent));
 									indent = 16;
 								}

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -22,7 +22,6 @@ import net.minecraft.client.gui.screen.option.CreditsAndAttributionScreen;
 import net.minecraft.client.gui.widget.ElementListWidget;
 import net.minecraft.client.gui.widget.EntryListWidget;
 import net.minecraft.client.render.*;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -207,7 +206,8 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 							children().add(new MojangCreditsEntry(line));
 						}
 					} else if (!"java".equals(mod.getId())) {
-						List<String> credits = mod.getCredits();
+						var credits = mod.getCredits();
+
 						if (!credits.isEmpty()) {
 							children().add(emptyEntry);
 
@@ -215,11 +215,28 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 								children().add(new DescriptionEntry(line));
 							}
 
-							for (String credit : credits) {
+							var iterator = credits.entrySet().iterator();
+
+							while (iterator.hasNext()) {
 								int indent = 8;
-								for (OrderedText line : textRenderer.wrapLines(Text.literal(credit), wrapWidth - 16)) {
+								var role = iterator.next();
+
+								for (var line : textRenderer.wrapLines(Text.literal(role.getKey() + ":"), wrapWidth - 16)) {
 									children().add(new DescriptionEntry(line, indent));
 									indent = 16;
+								}
+
+								for (var contributor : role.getValue()) {
+									indent = 16;
+
+									for (var line : textRenderer.wrapLines(Text.literal(contributor), wrapWidth - 24)) {
+										children().add(new DescriptionEntry(line, indent));
+										indent = 24;
+									}
+								}
+
+								if (iterator.hasNext()) {
+									children().add(emptyEntry);
 								}
 							}
 						}

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -68,11 +68,17 @@ public interface Mod {
 	@NotNull
 	List<String> getAuthors();
 
+	/**
+	 * @return a mapping of contributors to their roles.
+	 */
 	@NotNull
-	List<String> getContributors();
+	Map<String, Collection<String>> getContributors();
 
+	/**
+	 * @return a mapping of roles to each contributor with that role.
+	 */
 	@NotNull
-	List<String> getCredits();
+	SortedMap<String, Collection<String>> getCredits();
 
 	@NotNull
 	Set<Badge> getBadges();

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -78,7 +78,7 @@ public interface Mod {
 	 * @return a mapping of roles to each contributor with that role.
 	 */
 	@NotNull
-	SortedMap<String, Collection<String>> getCredits();
+	SortedMap<String, SortedSet<String>> getCredits();
 
 	@NotNull
 	Set<Badge> getBadges();

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
@@ -94,7 +94,7 @@ public class FabricDummyParentMod implements Mod {
 	}
 
 	@Override
-	public @NotNull SortedMap<String, Collection<String>> getCredits() {
+	public @NotNull SortedMap<String, SortedSet<String>> getCredits() {
 		return new TreeMap<>();
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
@@ -89,13 +89,13 @@ public class FabricDummyParentMod implements Mod {
 	}
 
 	@Override
-	public @NotNull List<String> getContributors() {
-		return new ArrayList<>();
+	public @NotNull Map<String, Collection<String>> getContributors() {
+		return Map.of();
 	}
 
 	@Override
-	public @NotNull List<String> getCredits() {
-		return new ArrayList<>();
+	public @NotNull SortedMap<String, Collection<String>> getCredits() {
+		return new TreeMap<>();
 	}
 
 	@Override

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -222,21 +222,20 @@ public class FabricMod implements Mod {
 	}
 
 	@Override
-	public @NotNull SortedMap<String, Collection<String>> getCredits() {
-		SortedMap<String, Collection<String>> credits = new TreeMap<>();
+	public @NotNull SortedMap<String, SortedSet<String>> getCredits() {
+		SortedMap<String, SortedSet<String>> credits = new TreeMap<>();
 
 		var authors = this.getAuthors();
+		var contributors = this.getContributors();
 
 		if (!authors.isEmpty()) {
-			credits.put("Author", authors);
+			contributors.put("Author", authors);
 		}
-
-		var contributors = this.getContributors();
 
 		for (var contributor : contributors.entrySet()) {
 			for (var role : contributor.getValue()) {
-				credits.computeIfAbsent(role, key -> new ArrayList<>());
-				credits.get(role).add(contributor.getKey()); // Add name
+				credits.computeIfAbsent(role, key -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER));
+				credits.get(role).add(contributor.getKey());
 			}
 		}
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -228,8 +228,8 @@ public class FabricMod implements Mod {
 		var authors = this.getAuthors();
 		var contributors = this.getContributors();
 
-		if (!authors.isEmpty()) {
-			contributors.put("Author", authors);
+		for (var author : authors) {
+			contributors.put(author, List.of("Author"));
 		}
 
 		for (var contributor : contributors.entrySet()) {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -211,20 +211,36 @@ public class FabricMod implements Mod {
 	}
 
 	@Override
-	public @NotNull List<String> getContributors() {
-		List<String> authors = metadata.getContributors().stream().map(Person::getName).collect(Collectors.toList());
-		if ("minecraft".equals(getId()) && authors.isEmpty()) {
-			return Lists.newArrayList();
+	public @NotNull Map<String, Collection<String>> getContributors() {
+		Map<String, Collection<String>> contributors = new HashMap<>();
+
+		for (var contributor : this.metadata.getContributors()) {
+			contributors.put(contributor.getName(), List.of("Contributor"));
 		}
-		return authors;
+
+		return contributors;
 	}
 
-	@NotNull
-	public List<String> getCredits() {
-		List<String> list = new ArrayList<>();
-		list.addAll(getAuthors());
-		list.addAll(getContributors());
-		return list;
+	@Override
+	public @NotNull SortedMap<String, Collection<String>> getCredits() {
+		SortedMap<String, Collection<String>> credits = new TreeMap<>();
+
+		var authors = this.getAuthors();
+
+		if (!authors.isEmpty()) {
+			credits.put("Author", authors);
+		}
+
+		var contributors = this.getContributors();
+
+		for (var contributor : contributors.entrySet()) {
+			for (var role : contributor.getValue()) {
+				credits.computeIfAbsent(role, key -> new ArrayList<>());
+				credits.get(role).add(contributor.getKey()); // Add name
+			}
+		}
+
+		return credits;
 	}
 
 	@Override

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
@@ -15,9 +15,15 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class QuiltMod extends FabricMod {
@@ -51,17 +57,30 @@ public class QuiltMod extends FabricMod {
 	}
 
 	@Override
-	public @NotNull List<String> getContributors() {
-		List<String> authors = metadata.contributors().stream().map(modContributor -> modContributor.name() + " (" + modContributor.role() + ")").collect(Collectors.toList());
-		if ("minecraft".equals(getId()) && authors.isEmpty()) {
-			return Lists.newArrayList();
+	public @NotNull Map<String, Collection<String>> getContributors() {
+		Map<String, Collection<String>> contributors = new HashMap<>();
+
+		for (var contributor : this.metadata.contributors()) {
+			contributors.put(contributor.name(), contributor.roles());
 		}
-		return authors;
+
+		return contributors;
 	}
 
 	@Override
-	public @NotNull List<String> getCredits() {
-		return this.getContributors();
+	public @NotNull SortedMap<String, Collection<String>> getCredits() {
+		SortedMap<String, Collection<String>> credits = new TreeMap<>();
+
+		var contributors = this.getContributors();
+
+		for (var contributor : contributors.entrySet()) {
+			for (var role : contributor.getValue()) {
+				credits.computeIfAbsent(role, key -> new ArrayList<>());
+				credits.get(role).add(contributor.getKey()); // Add name
+			}
+		}
+
+		return credits;
 	}
 
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/quilt/QuiltMod.java
@@ -23,7 +23,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public class QuiltMod extends FabricMod {
@@ -68,15 +70,15 @@ public class QuiltMod extends FabricMod {
 	}
 
 	@Override
-	public @NotNull SortedMap<String, Collection<String>> getCredits() {
-		SortedMap<String, Collection<String>> credits = new TreeMap<>();
+	public @NotNull SortedMap<String, SortedSet<String>> getCredits() {
+		SortedMap<String, SortedSet<String>> credits = new TreeMap<>();
 
 		var contributors = this.getContributors();
 
 		for (var contributor : contributors.entrySet()) {
 			for (var role : contributor.getValue()) {
-				credits.computeIfAbsent(role, key -> new ArrayList<>());
-				credits.get(role).add(contributor.getKey()); // Add name
+				credits.computeIfAbsent(role, key -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER));
+				credits.get(role).add(contributor.getKey());
 			}
 		}
 

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -93,6 +93,7 @@
   "modmenu.credits.role.maintainer": "Maintainers",
   "modmenu.credits.role.playtester": "Playtesters",
   "modmenu.credits.role.illustrator": "Illustrators",
+  "modmenu.credits.role.owner": "Owners",
 
   "modmenu.modsFolder": "Open Mods Folder",
   "modmenu.configsFolder": "Open Configs Folder",

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -87,6 +87,13 @@
   "modmenu.wiki": "Wiki",
   "modmenu.youtube": "YouTube",
 
+  "modmenu.credits.role.author": "Authors",
+  "modmenu.credits.role.contributor": "Contributors",
+  "modmenu.credits.role.translator": "Translators",
+  "modmenu.credits.role.maintainer": "Maintainers",
+  "modmenu.credits.role.playtester": "Playtesters",
+  "modmenu.credits.role.illustrator": "Illustrators",
+
   "modmenu.modsFolder": "Open Mods Folder",
   "modmenu.configsFolder": "Open Configs Folder",
 


### PR DESCRIPTION
Resolves #652 by grouping the credits by role names ([Fabric mod preview](https://files.lostluma.net/FUFCi4.png) / [Quilt mod preview](https://files.lostluma.net/XUy49I.png)).  
This is mostly useful on Quilt as we can actually assign contributor roles, but splits it into Authors and Contributors on Fabric.

I was not sure whether role names should be translatable as there is no standard for their names, so they are just displayed literally.