### PR TITLE
Fix user agent stripping not working

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -81,9 +81,9 @@ public class UpdateCheckerUtil {
 		List<String> loaders = ModMenu.runningQuilt ? List.of("fabric", "quilt") : List.of("fabric");
 
 		String mcVer = SharedConstants.getGameVersion().getName();
-		String[] splitVersion = FabricLoader.getInstance().getModContainer(ModMenu.MOD_ID)
-			.get().getMetadata().getVersion().getFriendlyString().split("\\+", 1); // Strip build metadata for privacy
-		final var modMenuVersion = splitVersion.length > 1 ? splitVersion[1] : splitVersion[0];
+		String version = FabricLoader.getInstance().getModContainer(ModMenu.MOD_ID)
+				.get().getMetadata().getVersion().getFriendlyString();
+		final var modMenuVersion = version.split("\\+", 2)[0]; // Strip build metadata for privacy
 		final var userAgent = "%s/%s (%s/%s%s)".formatted(ModMenu.GITHUB_REF, modMenuVersion, mcVer, primaryLoader, environment);
 		String body = ModMenu.GSON_MINIFIED.toJson(new LatestVersionsFromHashesBody(modHashes.keySet(), loaders, mcVer));
 		LOGGER.debug("User agent: " + userAgent);


### PR DESCRIPTION
The update checker is supposed to remove build metadata from the user agent as was introduced in https://github.com/TerraformersMC/ModMenu/commit/76cbca64fb16083a35ed98480495105a6db1dde8, however calling `String.split()` with a limit of 1 does not actually split the string in the first place, meaning this implementation never worked.