### PR TITLE
Skip unknown badge keys

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -1,5 +1,7 @@
 package com.terraformersmc.modmenu.util.mod;
 
+import com.google.common.base.Predicates;
+import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.api.UpdateChecker;
 import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
@@ -166,8 +168,17 @@ public interface Mod {
 			return this.fillColor;
 		}
 
-		public static Set<Badge> convert(Set<String> badgeKeys) {
-			return badgeKeys.stream().map(KEY_MAP::get).collect(Collectors.toSet());
+		public static Set<Badge> convert(Set<String> badgeKeys, String modId) {
+			return badgeKeys.stream()
+					.map(key -> {
+						if (!KEY_MAP.containsKey(key)) {
+							ModMenu.LOGGER.warn("Skipping unknown badge key '{}' specified by mod '{}'", key, modId);
+						}
+
+						return KEY_MAP.get(key);
+					})
+					.filter(Objects::nonNull)
+					.collect(Collectors.toSet());
 		}
 
 		static {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -51,7 +51,9 @@ public class FabricMod implements Mod {
 		this.container = modContainer;
 		this.metadata = modContainer.getMetadata();
 
-		if ("minecraft".equals(metadata.getId()) || "java".equals(metadata.getId())) {
+		String id = metadata.getId();
+
+		if ("minecraft".equals(id) || "java".equals(id)) {
 			allowsUpdateChecks = false;
 		}
 
@@ -77,13 +79,13 @@ public class FabricMod implements Mod {
 								CustomValueUtil.getString("icon", parentObj),
 								CustomValueUtil.getStringSet("badges", parentObj).orElse(new HashSet<>())
 						);
-						if (parentId.orElse("").equals(this.metadata.getId())) {
+						if (parentId.orElse("").equals(id)) {
 							parentId = Optional.empty();
 							parentData = null;
 							throw new RuntimeException("Mod declared itself as its own parent");
 						}
 					} catch (Throwable t) {
-						LOGGER.error("Error loading parent data from mod: " + metadata.getId(), t);
+						LOGGER.error("Error loading parent data from mod: " + id, t);
 					}
 				}
 			}
@@ -94,11 +96,11 @@ public class FabricMod implements Mod {
 		this.modMenuData = new ModMenuData(
 				badgeNames,
 				parentId,
-				parentData
+				parentData,
+				id
 		);
 
 		/* Hardcode parents and badges for Fabric API & Fabric Loader */
-		String id = metadata.getId();
 		if (id.startsWith("fabric") && metadata.containsCustomValue("fabric-api:module-lifecycle")) {
 			if (FabricLoader.getInstance().isModLoaded("fabric-api") || !FabricLoader.getInstance().isModLoaded("fabric")) {
 				modMenuData.fillParentIfEmpty("fabric-api");
@@ -365,8 +367,8 @@ public class FabricMod implements Mod {
 		private @Nullable
 		final DummyParentData dummyParentData;
 
-		public ModMenuData(Set<String> badges, Optional<String> parent, DummyParentData dummyParentData) {
-			this.badges = Badge.convert(badges);
+		public ModMenuData(Set<String> badges, Optional<String> parent, DummyParentData dummyParentData, String id) {
+			this.badges = Badge.convert(badges, id);
 			this.parent = parent;
 			this.dummyParentData = dummyParentData;
 		}
@@ -413,7 +415,7 @@ public class FabricMod implements Mod {
 				this.name = name;
 				this.description = description;
 				this.icon = icon;
-				this.badges = Badge.convert(badges);
+				this.badges = Badge.convert(badges, id);
 			}
 
 			public String getId() {


### PR DESCRIPTION
With this pull request, rather than crashing the game, Mod Menu will now log a warning:

```
[Render thread/WARN] (Mod Menu) Skipping unknown badge key 'nonexistent' specified by mod 'modmenu'
```

Fixes #693