### PR TITLE
Consistently draw text with shadows

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -313,17 +313,17 @@ public class ModsScreen extends Screen {
 			if (!ModMenuConfig.CONFIG_MODE.getValue() && this.updateFiltersX()) {
 				if (this.filterOptionsShown) {
 					if (!ModMenuConfig.SHOW_LIBRARIES.getValue() || textRenderer.getWidth(fullModCount) <= this.filtersX - 5) {
-						DrawContext.drawText(textRenderer, fullModCount.asOrderedText(), this.searchBoxX, 52, 0xFFFFFF, false);
+						DrawContext.drawText(textRenderer, fullModCount.asOrderedText(), this.searchBoxX, 52, 0xFFFFFF, true);
 					} else {
-						DrawContext.drawText(textRenderer, computeModCountText(false).asOrderedText(), this.searchBoxX, 46, 0xFFFFFF, false);
-						DrawContext.drawText(textRenderer, computeLibraryCountText().asOrderedText(), this.searchBoxX, 57, 0xFFFFFF, false);
+						DrawContext.drawText(textRenderer, computeModCountText(false).asOrderedText(), this.searchBoxX, 46, 0xFFFFFF, true);
+						DrawContext.drawText(textRenderer, computeLibraryCountText().asOrderedText(), this.searchBoxX, 57, 0xFFFFFF, true);
 					}
 				} else {
 					if (!ModMenuConfig.SHOW_LIBRARIES.getValue() || textRenderer.getWidth(fullModCount) <= modList.getWidth() - 5) {
-						DrawContext.drawText(textRenderer, fullModCount.asOrderedText(), this.searchBoxX, 52, 0xFFFFFF, false);
+						DrawContext.drawText(textRenderer, fullModCount.asOrderedText(), this.searchBoxX, 52, 0xFFFFFF, true);
 					} else {
-						DrawContext.drawText(textRenderer, computeModCountText(false).asOrderedText(), this.searchBoxX, 46, 0xFFFFFF, false);
-						DrawContext.drawText(textRenderer, computeLibraryCountText().asOrderedText(), this.searchBoxX, 57, 0xFFFFFF, false);
+						DrawContext.drawText(textRenderer, computeModCountText(false).asOrderedText(), this.searchBoxX, 46, 0xFFFFFF, true);
+						DrawContext.drawText(textRenderer, computeLibraryCountText().asOrderedText(), this.searchBoxX, 57, 0xFFFFFF, true);
 					}
 				}
 			}
@@ -347,7 +347,7 @@ public class ModsScreen extends Screen {
 				StringVisitable ellipsis = StringVisitable.plain("...");
 				trimmedName = StringVisitable.concat(textRenderer.trimToWidth(name, maxNameWidth - textRenderer.getWidth(ellipsis)), ellipsis);
 			}
-			DrawContext.drawText(textRenderer, Language.getInstance().reorder(trimmedName), x + imageOffset, RIGHT_PANE_Y + 1, 0xFFFFFF, false);
+			DrawContext.drawText(textRenderer, Language.getInstance().reorder(trimmedName), x + imageOffset, RIGHT_PANE_Y + 1, 0xFFFFFF, true);
 			if (mouseX > x + imageOffset && mouseY > RIGHT_PANE_Y + 1 && mouseY < RIGHT_PANE_Y + 1 + textRenderer.fontHeight && mouseX < x + imageOffset + textRenderer.getWidth(trimmedName)) {
 				this.setTooltip(ModMenuScreenTexts.modIdTooltip(mod.getId()));
 			}
@@ -359,7 +359,7 @@ public class ModsScreen extends Screen {
 				modBadgeRenderer.draw(DrawContext, mouseX, mouseY);
 			}
 			if (mod.isReal()) {
-				DrawContext.drawText(textRenderer, mod.getPrefixedVersion(), x + imageOffset, RIGHT_PANE_Y + 2 + lineSpacing, 0x808080, false);
+				DrawContext.drawText(textRenderer, mod.getPrefixedVersion(), x + imageOffset, RIGHT_PANE_Y + 2 + lineSpacing, 0x808080, true);
 			}
 			String authors;
 			List<String> names = mod.getAuthors();

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
@@ -67,7 +67,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 			StringVisitable ellipsis = StringVisitable.plain("...");
 			trimmedName = StringVisitable.concat(font.trimToWidth(name, maxNameWidth - font.getWidth(ellipsis)), ellipsis);
 		}
-		DrawContext.drawText(font, Language.getInstance().reorder(trimmedName), x + iconSize + 3, y + 1, 0xFFFFFF, false);
+		DrawContext.drawText(font, Language.getInstance().reorder(trimmedName), x + iconSize + 3, y + 1, 0xFFFFFF, true);
 		var updateBadgeXOffset = 0;
 		if (ModMenuConfig.UPDATE_CHECKER.getValue() && !ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue().contains(modId) && (mod.hasUpdate() || mod.getChildHasUpdate())) {
 			UpdateAvailableBadge.renderBadge(DrawContext, x + iconSize + 3 + font.getWidth(name) + 2, y);

--- a/src/main/java/com/terraformersmc/modmenu/util/DrawingUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/DrawingUtil.java
@@ -49,7 +49,7 @@ public class DrawingUtil {
 				int width = CLIENT.textRenderer.getWidth(line);
 				x1 += (float) (wrapWidth - width);
 			}
-			DrawContext.drawText(CLIENT.textRenderer, line, x1, y + i * CLIENT.textRenderer.fontHeight, color, false);
+			DrawContext.drawText(CLIENT.textRenderer, line, x1, y + i * CLIENT.textRenderer.fontHeight, color, true);
 		}
 	}
 


### PR DESCRIPTION
Previously, Mod Menu drew some text with shadows and some text without shadows. The lack of shadows on some text was less of an issue because the text was rendered on a contrasting dirt background. With Minecraft 1.20.5 using a panorama background instead, the lack of shadows on text now impacts the text's visibility.

This pull request updates text drawn without shadows to now have shadows:

![Mods screen with consistent text shadows](https://github.com/TerraformersMC/ModMenu/assets/24855774/a4ef74e5-d1a2-41ee-bfaa-2df20e5ef21d)

Note that badges are not affected by this change, as they are always rendered on top of a background specifically chose to contrast with the text color.