### PR TITLE
Update mod to Minecraft 1.20.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.5-rc3
-yarn_mappings=1.20.5-rc3+build.2
+minecraft_version=1.20.5
+yarn_mappings=1.20.5+build.1
 loader_version=0.15.10
-fabric_version=0.97.5+1.20.5
+fabric_version=0.97.8+1.20.5
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,13 +20,13 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.5-rc3
+modrinth_game_versions=1.20.5-pre2, 1.20.5-pre3, 1.20.5-pre4, 1.20.5-rc1, 1.20.5-rc2, 1.20.5-rc3, 1.20.5, 1.20.6-rc1
 modrinth_mod_loaders=fabric, quilt
 
 # CurseForge Metadata
 curseforge_slug=modmenu
 curseforge_id=308702
-curseforge_game_versions=1.20.5-Snapshot, Fabric, Quilt
+curseforge_game_versions=1.20.5-Snapshot, 1.20.5, Fabric, Quilt
 curseforge_required_dependencies=
 curseforge_optional_dependencies=
 


### PR DESCRIPTION
This pull request updates the mod to Minecraft 1.20.5 by changing values in `gradle.properties`. The existing beta release built using Minecraft 1.20.5 release candidate 3 should already work.

This version seems to currently support Minecraft 1.20.5 pre-release 2 through Minecraft 1.20.6 release candidate 1, as Minecraft 1.20.5 pre-release 1 crashes on launch due to an incompatible mixin within bundled Fabric API dependencies:

```
[Render thread/ERROR]: Mixin apply for mod fabric-resource-loader-v0 failed fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric-resource-loader-v0 -> net.minecraft.server.MinecraftServer: org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException Critical injection failure: @Redirect annotation on onCheckDisabled could not find any targets matching 'Lnet/minecraft/server/MinecraftServer;method_29736(Lnet/minecraft/class_3283;Lnet/minecraft/class_7712;ZZ)Lnet/minecraft/class_7712;' in net.minecraft.server.MinecraftServer. Using refmap fabric-resource-loader-v0-refmap.json [PREINJECT Applicator Phase -> fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric-resource-loader-v0 -> Prepare Injections ->  -> redirect$zbb000$fabric-resource-loader-v0$onCheckDisabled(Ljava/util/List;Ljava/lang/Object;Lnet/minecraft/class_3283;)Z -> Parse]
org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException: Critical injection failure: @Redirect annotation on onCheckDisabled could not find any targets matching 'Lnet/minecraft/server/MinecraftServer;method_29736(Lnet/minecraft/class_3283;Lnet/minecraft/class_7712;ZZ)Lnet/minecraft/class_7712;' in net.minecraft.server.MinecraftServer. Using refmap fabric-resource-loader-v0-refmap.json [PREINJECT Applicator Phase -> fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric-resource-loader-v0 -> Prepare Injections ->  -> redirect$zbb000$fabric-resource-loader-v0$onCheckDisabled(Ljava/util/List;Ljava/lang/Object;Lnet/minecraft/class_3283;)Z -> Parse]
```

CurseForge does not have a `1.20.6-Snapshot` version, so preliminary Minecraft 1.20.6 support will not be marked on CurseForge.