### PR TITLE
Fix Crash on 24w18a when clicks the ModMenuOptions of this mod #729

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
-loader_version=0.15.10
-fabric_version=0.97.8+1.20.6
+minecraft_version=24w18a
+yarn_mappings=24w18a+build.1
+loader_version=0.15.11
+fabric_version=0.98.0+1.21
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,13 +20,13 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.6
+modrinth_game_versions=24w18a
 modrinth_mod_loaders=fabric, quilt
 
 # CurseForge Metadata
 curseforge_slug=modmenu
 curseforge_id=308702
-curseforge_game_versions=1.20.6, Fabric, Quilt
+curseforge_game_versions=24w18a, Fabric, Quilt
 curseforge_required_dependencies=
 curseforge_optional_dependencies=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.5-rc3
-yarn_mappings=1.20.5-rc3+build.2
+minecraft_version=1.20.5
+yarn_mappings=1.20.5+build.1
 loader_version=0.15.10
 fabric_version=0.97.5+1.20.5
 quilt_loader_version=0.17.7
@@ -20,13 +20,13 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.5-rc3
+modrinth_game_versions=1.20.5
 modrinth_mod_loaders=fabric, quilt
 
 # CurseForge Metadata
 curseforge_slug=modmenu
 curseforge_id=308702
-curseforge_game_versions=1.20.5-Snapshot, Fabric, Quilt
+curseforge_game_versions=1.20.5, Fabric, Quilt
 curseforge_required_dependencies=
 curseforge_optional_dependencies=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.1
 loader_version=0.15.10
-fabric_version=0.97.5+1.20.5
+fabric_version=0.97.8+1.20.6
 quilt_loader_version=0.17.7
 
 # Project Metadata
@@ -20,13 +20,13 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=1.20.5
+modrinth_game_versions=1.20.6
 modrinth_mod_loaders=fabric, quilt
 
 # CurseForge Metadata
 curseforge_slug=modmenu
 curseforge_id=308702
-curseforge_game_versions=1.20.5, Fabric, Quilt
+curseforge_game_versions=1.20.6, Fabric, Quilt
 curseforge_required_dependencies=
 curseforge_optional_dependencies=
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModMenuOptionsScreen.java
@@ -21,9 +21,13 @@ public class ModMenuOptionsScreen extends GameOptionsScreen {
 
 	@Override
 	protected void init() {
-		this.list = this.addDrawableChild(new OptionListWidget(this.client, this.width, this.height, this));
+		this.list = this.addDrawableChild(new OptionListWidget(this.client, this.width, this));
 		this.list.addAll(ModMenuConfig.asOptions());
 		super.init();
+	}
+
+	@Override
+	protected void method_60325() {
 	}
 
 	@Override


### PR DESCRIPTION
#729 

The class GameOptionsScreen in 24w18a  changed to an abstract class. So the edit of  ModMenuModMenuCompat is needed.

1.20.6
```
public class GameOptionsScreen extends Screen 
```

24w18a
```
public abstract class GameOptionsScreen extends Screen 
```

So the edit of this is needed. Otherwise, the remap and compile won't success.