### PR TITLE
Update mod to Minecraft snapshot 24w36a

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 maven_group=com.terraformersmc
 archive_name=modmenu
 
-minecraft_version=24w34a
-yarn_mappings=24w34a+build.8
-loader_version=0.16.2
-fabric_version=0.102.2+1.21.2
+minecraft_version=24w36a
+yarn_mappings=24w36a+build.6
+loader_version=0.16.5
+fabric_version=0.104.0+1.21.2
 text_placeholder_api_version=2.4.0-pre.2+1.21
 quilt_loader_version=0.17.7
 
@@ -21,7 +21,7 @@ default_release_type=stable
 # Modrinth Metadata
 modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
-modrinth_game_versions=24w34a
+modrinth_game_versions=24w36a
 modrinth_mod_loaders=fabric, quilt
 modrinth_required_dependencies=fabric-api, placeholder-api
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
     "fabric-key-binding-api-v1": "*",
     "fabric-lifecycle-events-v1": "*",
     "fabricloader": ">=0.15.10",
-    "minecraft": ">=1.21-beta.2"
+    "minecraft": ">=1.21.2-"
   },
   "authors": [
     "Prospector",


### PR DESCRIPTION
The bundled Fabric API modules must be updated to fix a startup crash on Minecraft snapshot 24w36a.