### PR TITLE
Fix mod addition feature not recognizing Quilt mods

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -600,7 +600,7 @@ public class ModsScreen extends Screen {
 		Path modsDirectory = FabricLoader.getInstance().getGameDir().resolve("mods");
 
 		// Filter out none mods
-		List<Path> mods = paths.stream().filter(ModsScreen::isFabricMod).collect(Collectors.toList());
+		List<Path> mods = paths.stream().filter(ModsScreen::isValidMod).collect(Collectors.toList());
 
 		if (mods.isEmpty()) {
 			return;
@@ -638,9 +638,15 @@ public class ModsScreen extends Screen {
 		}, ModMenuScreenTexts.DROP_CONFIRM, Text.literal(modList)));
 	}
 
-	private static boolean isFabricMod(Path mod) {
+	private static boolean isValidMod(Path mod) {
 		try (JarFile jarFile = new JarFile(mod.toFile())) {
-			return jarFile.getEntry("fabric.mod.json") != null;
+			var isFabricMod = jarFile.getEntry("fabric.mod.json") != null;
+
+			if (!ModMenu.RUNNING_QUILT) {
+				return isFabricMod;
+			} else {
+				return isFabricMod || jarFile.getEntry("quilt.mod.json") != null;
+			}
 		} catch (IOException e) {
 			return false;
 		}


### PR DESCRIPTION
Fix Quilt mods not being recognized when dragged over the mods screen.  
This is only done when actually running Quilt to potentially lower confusion why a Quilt mod doesn't work on Fabric.