### PR TITLE
Fix mods screen initialization being slow with many  mods

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -102,26 +102,6 @@ public class ModsScreen extends Screen {
 
 	@Override
 	protected void init() {
-		for (Mod mod : ModMenu.MODS.values()) {
-			String id = mod.getId();
-			if (!modHasConfigScreen.containsKey(id)) {
-				try {
-					Screen configScreen = ModMenu.getConfigScreen(id, this);
-					modHasConfigScreen.put(id, configScreen != null);
-				} catch (java.lang.NoClassDefFoundError e) {
-					LOGGER.warn(
-						"The '" + id + "' mod config screen is not available because " + e.getLocalizedMessage() +
-							" is missing.");
-					modScreenErrors.put(id, e);
-					modHasConfigScreen.put(id, false);
-				} catch (Throwable e) {
-					LOGGER.error("Error from mod '" + id + "'", e);
-					modScreenErrors.put(id, e);
-					modHasConfigScreen.put(id, false);
-				}
-			}
-		}
-
 		int paneY = ModMenuConfig.CONFIG_MODE.getValue() ? 48 : 48 + 19;
 		this.paneWidth = this.width / 2 - 8;
 		this.rightPaneX = this.width - this.paneWidth;
@@ -203,9 +183,8 @@ public class ModsScreen extends Screen {
 		if (!ModMenuConfig.HIDE_CONFIG_BUTTONS.getValue()) {
 			this.configureButton = LegacyTexturedButtonWidget.legacyTexturedBuilder(ScreenTexts.EMPTY, button -> {
 					final String id = Objects.requireNonNull(selected).getMod().getId();
-					if (modHasConfigScreen.get(id)) {
-						Screen configScreen = ModMenu.getConfigScreen(id, this);
-						client.setScreen(configScreen);
+					if (getModHasConfigScreen(id)) {
+						this.safelyOpenConfigScreen(id);
 					} else {
 						button.active = false;
 					}
@@ -540,9 +519,9 @@ public class ModsScreen extends Screen {
 
 			if (this.configureButton != null) {
 
-				this.configureButton.active = modHasConfigScreen.get(modId);
+				this.configureButton.active = getModHasConfigScreen(modId);
 				this.configureButton.visible =
-					selected != null && modHasConfigScreen.get(modId) || modScreenErrors.containsKey(modId);
+					selected != null && getModHasConfigScreen(modId) || modScreenErrors.containsKey(modId);
 
 				if (modScreenErrors.containsKey(modId)) {
 					Throwable e = modScreenErrors.get(modId);
@@ -646,7 +625,29 @@ public class ModsScreen extends Screen {
 		}
 	}
 
-	public Map<String, Boolean> getModHasConfigScreen() {
-		return this.modHasConfigScreen;
+	public boolean getModHasConfigScreen(String modId) {
+		if (this.modScreenErrors.containsKey(modId)) {
+			return false;
+		} else {
+			return this.modHasConfigScreen.computeIfAbsent(modId, ModMenu::hasConfigScreen);
+		}
+	}
+
+	public void safelyOpenConfigScreen(String modId) {
+		try {
+			Screen screen = ModMenu.getConfigScreen(modId, this);
+
+			if (screen != null) {
+				this.client.setScreen(screen);
+			}
+		} catch (java.lang.NoClassDefFoundError e) {
+			LOGGER.warn(
+				"The '" + modId + "' mod config screen is not available because " + e.getLocalizedMessage() +
+					" is missing.");
+			modScreenErrors.put(modId, e);
+		} catch (Throwable e) {
+			LOGGER.error("Error from mod '" + modId + "'", e);
+			modScreenErrors.put(modId, e);
+		}
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -136,11 +136,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 		addedMods.clear();
 		Collection<Mod> mods = ModMenu.MODS.values().stream().filter(mod -> {
 			if (ModMenuConfig.CONFIG_MODE.getValue()) {
-				Map<String, Boolean> modHasConfigScreen = parent.getModHasConfigScreen();
-				var hasConfig = modHasConfigScreen.get(mod.getId());
-				if (!hasConfig) {
-					return false;
-				}
+				return !parent.getModHasConfigScreen(mod.getId());
 			}
 
 			return !mod.isHidden();

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
@@ -124,8 +124,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		}
 
 		if (!(this instanceof ParentEntry) && ModMenuConfig.QUICK_CONFIGURE.getValue() && (this.list.getParent()
-			.getModHasConfigScreen()
-			.get(modId) || this.list.getParent().modScreenErrors.containsKey(modId))) {
+			.getModHasConfigScreen(modId) || this.list.getParent().modScreenErrors.containsKey(modId))) {
 			final int textureSize = ModMenuConfig.COMPACT_LIST.getValue() ?
 				(int) (256 / (FULL_ICON_SIZE / (double) COMPACT_ICON_SIZE)) :
 				256;
@@ -167,9 +166,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int delta) {
 		list.select(this);
-		if (ModMenuConfig.QUICK_CONFIGURE.getValue() && this.list.getParent()
-			.getModHasConfigScreen()
-			.get(this.mod.getId())) {
+		if (ModMenuConfig.QUICK_CONFIGURE.getValue() && this.list.getParent().getModHasConfigScreen(this.mod.getId())) {
 			int iconSize = ModMenuConfig.COMPACT_LIST.getValue() ? COMPACT_ICON_SIZE : FULL_ICON_SIZE;
 			if (mouseX - list.getRowLeft() <= iconSize) {
 				this.openConfig();
@@ -182,7 +179,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 	}
 
 	public void openConfig() {
-		MinecraftClient.getInstance().setScreen(ModMenu.getConfigScreen(mod.getId(), list.getParent()));
+		this.list.getParent().safelyOpenConfigScreen(mod.getId());
 	}
 
 	public Mod getMod() {

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
@@ -68,8 +68,7 @@ public class ModSearch {
 			|| deprecated.contains(query) && mod.getBadges()
 			.contains(Mod.Badge.DEPRECATED) // Search for deprecated mods
 			|| clientside.contains(query) && mod.getBadges().contains(Mod.Badge.CLIENT) // Search for clientside mods
-			|| configurable.contains(query) && screen.getModHasConfigScreen()
-			.get(modId) // Search for mods that can be configured
+			|| configurable.contains(query) && screen.getModHasConfigScreen(modId) // Search for mods that can be configured
 			|| hasUpdate.contains(query) && mod.hasUpdate() // Search for mods that have updates
 		) {
 			return 1;


### PR DESCRIPTION
Resolves #727.

Changes the check for whether a mod has a config screen to check whether a config screen factory is available, and defers actually constructing individual config screens until the user actually clicks the configure button.

As a side-effect broken config screens are no longer reported on until the user has tried opening the config screen at least once, but I think this should be an acceptable change considering the improved user experience otherwise.