### PR TITLE
New Sorting Type: Has Update

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
@@ -89,8 +89,9 @@ public class ModMenuConfig {
 	}
 
 	public enum Sorting {
-		ASCENDING(Comparator.comparing(mod -> mod.getTranslatedName()
-			.toLowerCase(Locale.ROOT))), DESCENDING(ASCENDING.getComparator().reversed());
+		ASCENDING(Comparator.comparing(mod -> mod.getTranslatedName().toLowerCase(Locale.ROOT))),
+		DESCENDING(ASCENDING.getComparator().reversed()),
+		HAS_UPDATE(Comparator.comparing(Mod::hasUpdate).reversed());
 
 		private final Comparator<Mod> comparator;
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -140,7 +140,7 @@ public class ModsScreen extends Screen {
 		Text sortingText = ModMenuConfig.SORTING.getButtonText();
 		Text librariesText = ModMenuConfig.SHOW_LIBRARIES.getButtonText();
 
-		int sortingWidth = textRenderer.getWidth(sortingText) + 20;
+		int sortingWidth = textRenderer.getWidth(sortingText) + 28;
 		int librariesWidth = textRenderer.getWidth(librariesText) + 20;
 
 		this.filtersWidth = librariesWidth + sortingWidth + 2;

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -4,7 +4,7 @@
   "modmenu.title": "Mods",
   "modmenu.nameTranslation.modmenu": "Mod Menu",
   "modmenu.descriptionTranslation.modmenu": "Adds a mod menu to view the list of mods you have installed.",
-  
+
   "modmenu.loaded": "(%s Loaded)",
   "modmenu.loaded.short": "(%s)",
   "modmenu.loaded.69.secret": "(%s Loaded...nice)",
@@ -13,7 +13,7 @@
   "modmenu.mods.1": " (%s Mod)",
   "modmenu.mods.69.secret": " (%s Mods...nice)",
   "modmenu.mods.420.secret": " (%s Mods...blaze it)",
-  
+
   "modmenu.search": "Search for mods",
   "modmenu.searchTerms.library": "api library",
   "modmenu.searchTerms.patchwork": "patchwork forge fml",
@@ -22,7 +22,7 @@
   "modmenu.searchTerms.clientside": "clientside gameside",
   "modmenu.searchTerms.configurable": "configurations configs configures configurable options settings",
   "modmenu.searchTerms.hasUpdate": "updates version",
-  
+
   "modmenu.toggleFilterOptions": "Toggle Filter Options",
   "modmenu.showingMods.n": "Showing %s mods",
   "modmenu.showingMods.1": "Showing %s mod",
@@ -32,20 +32,20 @@
   "modmenu.showingModsLibraries.n.1": "Showing %s mods and %s library",
   "modmenu.showingModsLibraries.1.n": "Showing %s mod and %s libraries",
   "modmenu.showingModsLibraries.1.1": "Showing %s mod and %s library",
-  
+
   "modmenu.badge.library": "Library",
   "modmenu.badge.clientsideOnly": "Client",
   "modmenu.badge.deprecated": "Deprecated",
   "modmenu.badge.forge": "Forge",
   "modmenu.badge.modpack": "Modpack",
   "modmenu.badge.minecraft": "Minecraft",
-  
+
   "modmenu.dropInfo.line1": "Drag and drop files into",
   "modmenu.dropInfo.line2": "this window to add mods",
   "modmenu.dropConfirm": "Do you want to copy the following mods into the mods directory?",
   "modmenu.dropSuccessful.line1": "Successfully copied mods",
   "modmenu.dropSuccessful.line2": "Restart game to load mods",
-  
+
   "modmenu.modIdToolTip": "Mod ID: %s",
   "modmenu.authorPrefix": "By %s",
   "modmenu.config": "Edit Config",
@@ -53,7 +53,7 @@
   "modmenu.configure.error": "Failed to load config screen for '%s'\nReport to '%s', not Mod Menu",
   "modmenu.website": "Website",
   "modmenu.issues": "Issues",
-  
+
   "modmenu.credits": "Credits:",
   "modmenu.viewCredits": "View Credits",
   "modmenu.license": "License:",
@@ -65,7 +65,7 @@
   "modmenu.updateText": "v%s on %s",
   "modmenu.install_version": "Install version %s",
   "modmenu.downloadLink": "Download",
-  
+
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",
@@ -87,7 +87,7 @@
   "modmenu.twitter": "X (Twitter)",
   "modmenu.wiki": "Wiki",
   "modmenu.youtube": "YouTube",
-  
+
   "modmenu.credits.role.author": "Authors",
   "modmenu.credits.role.contributor": "Contributors",
   "modmenu.credits.role.translator": "Translators",
@@ -95,20 +95,21 @@
   "modmenu.credits.role.playtester": "Playtesters",
   "modmenu.credits.role.illustrator": "Illustrators",
   "modmenu.credits.role.owner": "Owners",
-  
+
   "modmenu.modsFolder": "Open Mods Folder",
   "modmenu.configsFolder": "Open Configs Folder",
-  
+
   "modmenu.nameTranslation.minecraft": "Minecraft",
   "modmenu.descriptionTranslation.minecraft": "The base game.",
   "modmenu.nameTranslation.java": "Java",
   "modmenu.descriptionTranslation.java": "The Java runtime environment.",
   "modmenu.javaDistributionName": "Running: %s",
-  
+
   "modmenu.options": "Mod Menu Options",
   "option.modmenu.sorting": "Sort",
   "option.modmenu.sorting.ascending": "A-Z",
   "option.modmenu.sorting.descending": "Z-A",
+  "option.modmenu.sorting.has_update": "Has Update",
   "option.modmenu.show_libraries": "Libraries",
   "option.modmenu.show_libraries.true": "Shown",
   "option.modmenu.show_libraries.false": "Hidden",

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -4,7 +4,7 @@
   "modmenu.title": "Mods",
   "modmenu.nameTranslation.modmenu": "Mod Menu",
   "modmenu.descriptionTranslation.modmenu": "Adds a mod menu to view the list of mods you have installed.",
-
+  
   "modmenu.loaded": "(%s Loaded)",
   "modmenu.loaded.short": "(%s)",
   "modmenu.loaded.69.secret": "(%s Loaded...nice)",
@@ -13,7 +13,7 @@
   "modmenu.mods.1": " (%s Mod)",
   "modmenu.mods.69.secret": " (%s Mods...nice)",
   "modmenu.mods.420.secret": " (%s Mods...blaze it)",
-
+  
   "modmenu.search": "Search for mods",
   "modmenu.searchTerms.library": "api library",
   "modmenu.searchTerms.patchwork": "patchwork forge fml",
@@ -22,7 +22,7 @@
   "modmenu.searchTerms.clientside": "clientside gameside",
   "modmenu.searchTerms.configurable": "configurations configs configures configurable options settings",
   "modmenu.searchTerms.hasUpdate": "updates version",
-
+  
   "modmenu.toggleFilterOptions": "Toggle Filter Options",
   "modmenu.showingMods.n": "Showing %s mods",
   "modmenu.showingMods.1": "Showing %s mod",
@@ -32,20 +32,20 @@
   "modmenu.showingModsLibraries.n.1": "Showing %s mods and %s library",
   "modmenu.showingModsLibraries.1.n": "Showing %s mod and %s libraries",
   "modmenu.showingModsLibraries.1.1": "Showing %s mod and %s library",
-
+  
   "modmenu.badge.library": "Library",
   "modmenu.badge.clientsideOnly": "Client",
   "modmenu.badge.deprecated": "Deprecated",
   "modmenu.badge.forge": "Forge",
   "modmenu.badge.modpack": "Modpack",
   "modmenu.badge.minecraft": "Minecraft",
-
+  
   "modmenu.dropInfo.line1": "Drag and drop files into",
   "modmenu.dropInfo.line2": "this window to add mods",
   "modmenu.dropConfirm": "Do you want to copy the following mods into the mods directory?",
   "modmenu.dropSuccessful.line1": "Successfully copied mods",
   "modmenu.dropSuccessful.line2": "Restart game to load mods",
-
+  
   "modmenu.modIdToolTip": "Mod ID: %s",
   "modmenu.authorPrefix": "By %s",
   "modmenu.config": "Edit Config",
@@ -53,7 +53,7 @@
   "modmenu.configure.error": "Failed to load config screen for '%s'\nReport to '%s', not Mod Menu",
   "modmenu.website": "Website",
   "modmenu.issues": "Issues",
-
+  
   "modmenu.credits": "Credits:",
   "modmenu.viewCredits": "View Credits",
   "modmenu.license": "License:",
@@ -65,7 +65,7 @@
   "modmenu.updateText": "v%s on %s",
   "modmenu.install_version": "Install version %s",
   "modmenu.downloadLink": "Download",
-
+  
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",
@@ -87,7 +87,7 @@
   "modmenu.twitter": "X (Twitter)",
   "modmenu.wiki": "Wiki",
   "modmenu.youtube": "YouTube",
-
+  
   "modmenu.credits.role.author": "Authors",
   "modmenu.credits.role.contributor": "Contributors",
   "modmenu.credits.role.translator": "Translators",
@@ -95,16 +95,16 @@
   "modmenu.credits.role.playtester": "Playtesters",
   "modmenu.credits.role.illustrator": "Illustrators",
   "modmenu.credits.role.owner": "Owners",
-
+  
   "modmenu.modsFolder": "Open Mods Folder",
   "modmenu.configsFolder": "Open Configs Folder",
-
+  
   "modmenu.nameTranslation.minecraft": "Minecraft",
   "modmenu.descriptionTranslation.minecraft": "The base game.",
   "modmenu.nameTranslation.java": "Java",
   "modmenu.descriptionTranslation.java": "The Java runtime environment.",
   "modmenu.javaDistributionName": "Running: %s",
-
+  
   "modmenu.options": "Mod Menu Options",
   "option.modmenu.sorting": "Sort",
   "option.modmenu.sorting.ascending": "A-Z",


### PR DESCRIPTION
Adds a new sorting type which orders mods with updates first.

I often find myself searching through the mods list for which mods need updates, and figured having a sort type for that could be useful.