### PR TITLE
Add null check for selection change, close #807

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -80,7 +80,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 	@Override
 	public void setSelected(ModListEntry entry) {
 		super.setSelected(entry);
-		selectedModId = entry.getMod().getId();
+		selectedModId = entry == null ? "" : entry.getMod().getId();
 		parent.updateSelectedEntry(getSelectedOrNull());
 	}
 


### PR DESCRIPTION
This fixes a new NPE on 1.21.4 (13.0.0-beta.1) which can be triggered by navigating to the bottom of the mod list using the down key, or using the left key at all while focused on the mod list.

It does not directly address any Minecraft changes that may have caused this to become a problem on 1.21.4.