### PR TITLE
Change type of dependencies from required to embedded

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,13 +23,13 @@ modrinth_slug=modmenu
 modrinth_id=mOgUt4GM
 modrinth_game_versions=1.21.4-rc3, 1.21.4
 modrinth_mod_loaders=fabric, quilt
-modrinth_required_dependencies=fabric-api, placeholder-api
+modrinth_embedded_dependencies=fabric-api, placeholder-api
 
 # CurseForge Metadata
 curseforge_slug=modmenu
 curseforge_id=308702
 curseforge_game_versions=1.21.4, Fabric, Quilt
-curseforge_required_dependencies=fabric-api, text-placeholder-api
+curseforge_required_dependencies=
 curseforge_optional_dependencies=
 
 # Mod Loader Metadata


### PR DESCRIPTION
Replaces `modrinth_required_dependencies` with `modrinth_embedded_dependencies` for Fabric API and Text Placeholder API as well as completely removes them from CF dependencies.

This should resolve #756 and #781