### PR TITLE
Fix keyboard navigation crash

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
 import net.minecraft.client.render.*;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.lwjgl.glfw.GLFW;
 
@@ -78,9 +79,13 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 	}
 
 	@Override
-	public void setSelected(ModListEntry entry) {
+	public void setSelected(@Nullable ModListEntry entry) {
 		super.setSelected(entry);
-		selectedModId = entry.getMod().getId();
+		if (entry == null) {
+			selectedModId = null;
+		} else {
+			selectedModId = entry.getMod().getId();
+		}
 		parent.updateSelectedEntry(getSelectedOrNull());
 	}
 


### PR DESCRIPTION
As of 1.21.4 the parameter of the method setSelected is Nullable. 
Without this PR trying to press arrow down while having the last mod entry selected will result in the game crashing. 
Null means that we have exhausted the list, so I set the selectedModId to null as is done on class initialization when no mod is selected.

As far as I could tell this restores the behavior of old versions. 