### PR TITLE
Clean up shader references

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -1,7 +1,6 @@
 package com.terraformersmc.modmenu.gui;
 
 import com.google.common.base.Joiner;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.config.ModMenuConfigManager;
@@ -297,24 +296,23 @@ public class ModsScreen extends Screen {
 	}
 
 	@Override
-	public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		super.render(DrawContext, mouseX, mouseY, delta);
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+		super.render(context, mouseX, mouseY, delta);
 		ModListEntry selectedEntry = selected;
 		if (selectedEntry != null) {
-			this.descriptionListWidget.render(DrawContext, mouseX, mouseY, delta);
+			this.descriptionListWidget.render(context, mouseX, mouseY, delta);
 		}
-		this.modList.render(DrawContext, mouseX, mouseY, delta);
-		this.searchBox.render(DrawContext, mouseX, mouseY, delta);
-		RenderSystem.disableBlend();
-		DrawContext.drawCenteredTextWithShadow(this.textRenderer, this.title, this.modList.getWidth() / 2, 8, 16777215);
+		this.modList.render(context, mouseX, mouseY, delta);
+		this.searchBox.render(context, mouseX, mouseY, delta);
+		context.drawCenteredTextWithShadow(this.textRenderer, this.title, this.modList.getWidth() / 2, 8, 16777215);
 		if (!ModMenuConfig.DISABLE_DRAG_AND_DROP.getValue()) {
-			DrawContext.drawCenteredTextWithShadow(this.textRenderer,
+			context.drawCenteredTextWithShadow(this.textRenderer,
 				ModMenuScreenTexts.DROP_INFO_LINE_1,
 				this.width - this.modList.getWidth() / 2,
 				RIGHT_PANE_Y / 2 - client.textRenderer.fontHeight - 1,
 				Formatting.GRAY.getColorValue()
 			);
-			DrawContext.drawCenteredTextWithShadow(this.textRenderer,
+			context.drawCenteredTextWithShadow(this.textRenderer,
 				ModMenuScreenTexts.DROP_INFO_LINE_2,
 				this.width - this.modList.getWidth() / 2,
 				RIGHT_PANE_Y / 2 + 1,
@@ -327,7 +325,7 @@ public class ModsScreen extends Screen {
 				if (this.filterOptionsShown) {
 					if (!ModMenuConfig.SHOW_LIBRARIES.getValue() ||
 						textRenderer.getWidth(fullModCount) <= this.filtersX - 5) {
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							fullModCount.asOrderedText(),
 							this.searchBoxX,
 							52,
@@ -335,14 +333,14 @@ public class ModsScreen extends Screen {
 							true
 						);
 					} else {
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							computeModCountText(false, false).asOrderedText(),
 							this.searchBoxX,
 							46,
 							0xFFFFFF,
 							true
 						);
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							computeLibraryCountText(false).asOrderedText(),
 							this.searchBoxX,
 							57,
@@ -353,7 +351,7 @@ public class ModsScreen extends Screen {
 				} else {
 					if (!ModMenuConfig.SHOW_LIBRARIES.getValue() ||
 						textRenderer.getWidth(fullModCount) <= modList.getWidth() - 5) {
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							fullModCount.asOrderedText(),
 							this.searchBoxX,
 							52,
@@ -361,14 +359,14 @@ public class ModsScreen extends Screen {
 							true
 						);
 					} else {
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							computeModCountText(false, false).asOrderedText(),
 							this.searchBoxX,
 							46,
 							0xFFFFFF,
 							true
 						);
-						DrawContext.drawText(textRenderer,
+						context.drawText(textRenderer,
 							computeLibraryCountText(false).asOrderedText(),
 							this.searchBoxX,
 							57,
@@ -383,24 +381,14 @@ public class ModsScreen extends Screen {
 			Mod mod = selectedEntry.getMod();
 			int x = this.rightPaneX;
 			if ("java".equals(mod.getId())) {
-				DrawingUtil.drawRandomVersionBackground(mod, DrawContext, x, RIGHT_PANE_Y, 32, 32);
+				DrawingUtil.drawRandomVersionBackground(mod, context, x, RIGHT_PANE_Y, 32, 32);
 			}
-			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-			RenderSystem.enableBlend();
-			DrawContext.drawTexture(RenderLayer::getGuiTextured, this.selected.getIconTexture(), x, RIGHT_PANE_Y, 0.0F, 0.0F, 32, 32, 32, 32);
-			RenderSystem.disableBlend();
+			context.drawTexture(RenderLayer::getGuiTextured, this.selected.getIconTexture(), x, RIGHT_PANE_Y, 0.0F, 0.0F, 32, 32, 32, 32);
 			int lineSpacing = textRenderer.fontHeight + 1;
 			int imageOffset = 36;
 			Text name = Text.literal(mod.getTranslatedName());
-			StringVisitable trimmedName = name;
-			int maxNameWidth = this.width - (x + imageOffset);
-			if (textRenderer.getWidth(name) > maxNameWidth) {
-				StringVisitable ellipsis = StringVisitable.plain("...");
-				trimmedName = StringVisitable.concat(textRenderer.trimToWidth(name,
-					maxNameWidth - textRenderer.getWidth(ellipsis)
-				), ellipsis);
-			}
-			DrawContext.drawText(textRenderer,
+			StringVisitable trimmedName = DrawingUtil.getTrimmedName(name, this.width - (x + imageOffset), this.textRenderer);
+			context.drawText(textRenderer,
 				Language.getInstance().reorder(trimmedName),
 				x + imageOffset,
 				RIGHT_PANE_Y + 1,
@@ -423,10 +411,10 @@ public class ModsScreen extends Screen {
 				this.init = false;
 			}
 			if (!ModMenuConfig.HIDE_BADGES.getValue()) {
-				modBadgeRenderer.draw(DrawContext, mouseX, mouseY);
+				modBadgeRenderer.draw(context, mouseX, mouseY);
 			}
 			if (mod.isReal()) {
-				DrawContext.drawText(textRenderer,
+				context.drawText(textRenderer,
 					mod.getPrefixedVersion(),
 					x + imageOffset,
 					RIGHT_PANE_Y + 2 + lineSpacing,
@@ -443,7 +431,7 @@ public class ModsScreen extends Screen {
 				} else {
 					authors = names.get(0);
 				}
-				DrawingUtil.drawWrappedString(DrawContext,
+				DrawingUtil.drawWrappedString(context,
 					I18n.translate("modmenu.authorPrefix", authors),
 					x + imageOffset,
 					RIGHT_PANE_Y + 2 + lineSpacing * 2,

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -1,7 +1,5 @@
 package com.terraformersmc.modmenu.gui.widget;
 
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
@@ -9,9 +7,6 @@ import com.terraformersmc.modmenu.gui.widget.entries.ModListEntry;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gl.GlUsage;
-import net.minecraft.client.gl.ShaderProgramKeys;
-import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
@@ -21,12 +16,11 @@ import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.gui.screen.option.CreditsAndAttributionScreen;
 import net.minecraft.client.gui.widget.ElementListWidget;
 import net.minecraft.client.gui.widget.EntryListWidget;
-import net.minecraft.client.render.*;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
-import net.minecraft.util.math.MathHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +44,12 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		.formatted(Formatting.BLUE)
 		.formatted(Formatting.UNDERLINE);
 	private static final Text CREDITS_TEXT = Text.translatable("modmenu.credits");
+
+	private static final int BLACK = Colors.BLACK;
+	private static final int TRANSPARENT = 0x00000000;
+
+	private static final int SHADOW_HEIGHT = 4;
+	private static final int SHADOW_Z = 200;
 
 	private final ModsScreen parent;
 	private final TextRenderer textRenderer;
@@ -90,7 +90,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 	}
 
 	@Override
-	public void renderList(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
+	public void renderList(DrawContext context, int mouseX, int mouseY, float delta) {
 		ModListEntry selectedEntry = parent.getSelectedEntry();
 		if (selectedEntry != lastSelected) {
 			lastSelected = selectedEntry;
@@ -264,126 +264,18 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			}
 		}
 
-		Tessellator tessellator = Tessellator.getInstance();
-		BufferBuilder bufferBuilder;
-		BuiltBuffer builtBuffer;
-
-		//		{
-		//			RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-		//			RenderSystem.setShaderTexture(0, Screen.OPTIONS_BACKGROUND_TEXTURE);
-		//			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-		//			bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-		//			bufferBuilder.vertex(this.getX(), this.getBottom(), 0.0D).texture(this.getX() / 32.0F, (this.getBottom() + (int) this.getScrollAmount()) / 32.0F).color(32, 32, 32, 255);
-		//			bufferBuilder.vertex(this.getRight(), this.getBottom(), 0.0D).texture(this.getRight() / 32.0F, (this.getBottom() + (int) this.getScrollAmount()) / 32.0F).color(32, 32, 32, 255);
-		//			bufferBuilder.vertex(this.getRight(), this.getY(), 0.0D).texture(this.getRight() / 32.0F, (this.getY() + (int) this.getScrollAmount()) / 32.0F).color(32, 32, 32, 255);
-		//			bufferBuilder.vertex(this.getX(), this.getY(), 0.0D).texture(this.getX() / 32.0F, (this.getY() + (int) this.getScrollAmount()) / 32.0F).color(32, 32, 32, 255);
-		//			tessellator.draw();
-		//		}
-
-		this.enableScissor(DrawContext);
-		super.renderList(DrawContext, mouseX, mouseY, delta);
-		DrawContext.disableScissor();
-
-		RenderSystem.depthFunc(515);
-		RenderSystem.disableDepthTest();
-		RenderSystem.enableBlend();
-		RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA,
-			GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-			GlStateManager.SrcFactor.ZERO,
-			GlStateManager.DstFactor.ONE
-		);
-//		RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-		RenderSystem.setShader(ShaderProgramKeys.POSITION_COLOR);
-
-		bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
-		bufferBuilder.vertex(this.getX(), (this.getY() + 4), 0.0F).
-
-			color(0, 0, 0, 0);
-
-		bufferBuilder.vertex(this.getRight(), (this.getY() + 4), 0.0F).
-
-			color(0, 0, 0, 0);
-
-		bufferBuilder.vertex(this.getRight(), this.getY(), 0.0F).
-
-			color(0, 0, 0, 255);
-
-		bufferBuilder.vertex(this.getX(), this.getY(), 0.0F).
-
-			color(0, 0, 0, 255);
-
-		bufferBuilder.vertex(this.getX(), this.getBottom(), 0.0F).
-
-			color(0, 0, 0, 255);
-
-		bufferBuilder.vertex(this.getRight(), this.getBottom(), 0.0F).
-
-			color(0, 0, 0, 255);
-
-		bufferBuilder.vertex(this.getRight(), (this.getBottom() - 4), 0.0F).
-
-			color(0, 0, 0, 0);
-
-		bufferBuilder.vertex(this.getX(), (this.getBottom() - 4), 0.0F).
-
-			color(0, 0, 0, 0);
-
-		try {
-			builtBuffer = bufferBuilder.end();
-
-			try (VertexBuffer vertexBuffer = new VertexBuffer(GlUsage.STATIC_WRITE)) {
-				vertexBuffer.bind();
-				vertexBuffer.upload(builtBuffer);
-				vertexBuffer.draw(RenderSystem.getModelViewMatrix(), RenderSystem.getProjectionMatrix(), RenderSystem.getShader());
-				builtBuffer.close();
-			}
-		} catch (Exception e) {
-			// Ignored
-		}
-		this.renderScrollBar(bufferBuilder, tessellator);
-
-		RenderSystem.disableBlend();
+		super.renderList(context, mouseX, mouseY, delta);
 	}
 
-	public void renderScrollBar(BufferBuilder bufferBuilder, Tessellator tessellator) {
-		BuiltBuffer builtBuffer;
-		int scrollbarStartX = this.getScrollbarX();
-		int scrollbarEndX = scrollbarStartX + 6;
-		int maxScroll = this.getMaxScrollY();
-		if (maxScroll > 0) {
-			int p = (int) ((float) ((this.getBottom() - this.getY()) * (this.getBottom() - this.getY())) / (float) this.getContentsHeightWithPadding());
-			p = MathHelper.clamp(p, 32, this.getBottom() - this.getY() - 8);
-			int q = (int) this.getScrollY() * (this.getBottom() - this.getY() - p) / maxScroll + this.getY();
-			if (q < this.getY()) {
-				q = this.getY();
-			}
+	@Override
+	protected void drawScrollbar(DrawContext context) {
+		int startX = this.getX();
+		int endX = this.overflows() ? this.getScrollbarX() : this.getRight();
 
-			bufferBuilder = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
-			bufferBuilder.vertex(scrollbarStartX, this.getBottom(), 0.0F).color(0, 0, 0, 255);
-			bufferBuilder.vertex(scrollbarEndX, this.getBottom(), 0.0F).color(0, 0, 0, 255);
-			bufferBuilder.vertex(scrollbarEndX, this.getY(), 0.0F).color(0, 0, 0, 255);
-			bufferBuilder.vertex(scrollbarStartX, this.getY(), 0.0F).color(0, 0, 0, 255);
-			bufferBuilder.vertex(scrollbarStartX, q + p, 0.0F).color(128, 128, 128, 255);
-			bufferBuilder.vertex(scrollbarEndX, q + p, 0.0F).color(128, 128, 128, 255);
-			bufferBuilder.vertex(scrollbarEndX, q, 0.0F).color(128, 128, 128, 255);
-			bufferBuilder.vertex(scrollbarStartX, q, 0.0F).color(128, 128, 128, 255);
-			bufferBuilder.vertex(scrollbarStartX, q + p - 1, 0.0F).color(192, 192, 192, 255);
-			bufferBuilder.vertex(scrollbarEndX - 1, q + p - 1, 0.0F).color(192, 192, 192, 255);
-			bufferBuilder.vertex(scrollbarEndX - 1, q, 0.0F).color(192, 192, 192, 255);
-			bufferBuilder.vertex(scrollbarStartX, q, 0.0F).color(192, 192, 192, 255);
-			try {
-				builtBuffer = bufferBuilder.end();
+		context.fillGradient(startX, this.getY(), endX, this.getY() + SHADOW_HEIGHT, SHADOW_Z, BLACK, TRANSPARENT);
+		context.fillGradient(startX, this.getBottom() - SHADOW_HEIGHT, endX, this.getBottom(), SHADOW_Z, TRANSPARENT, BLACK);
 
-				try (VertexBuffer vertexBuffer = new VertexBuffer(GlUsage.STATIC_WRITE)) {
-					vertexBuffer.bind();
-					vertexBuffer.upload(builtBuffer);
-					vertexBuffer.draw(RenderSystem.getModelViewMatrix(), RenderSystem.getProjectionMatrix(), RenderSystem.getShader());
-					builtBuffer.close();
-				}
-			} catch (Exception e) {
-				// Ignored
-			}
-		}
+		super.drawScrollbar(context);
 	}
 
 	private Text creditsRoleText(String roleName) {
@@ -420,7 +312,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 		@Override
 		public void render(
-			DrawContext DrawContext,
+			DrawContext context,
 			int index,
 			int y,
 			int x,
@@ -432,10 +324,10 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			float delta
 		) {
 			if (updateTextEntry) {
-				UpdateAvailableBadge.renderBadge(DrawContext, x + indent, y);
+				UpdateAvailableBadge.renderBadge(context, x + indent, y);
 				x += 11;
 			}
-			DrawContext.drawTextWithShadow(textRenderer, text, x + indent, y, 0xAAAAAA);
+			context.drawTextWithShadow(textRenderer, text, x + indent, y, 0xAAAAAA);
 		}
 
 		@Override

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModMenuButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModMenuButtonWidget.java
@@ -22,10 +22,10 @@ public class ModMenuButtonWidget extends ButtonWidget {
 	}
 
 	@Override
-	public void renderWidget(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		super.renderWidget(DrawContext, mouseX, mouseY, delta);
+	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+		super.renderWidget(context, mouseX, mouseY, delta);
 		if (ModMenuConfig.BUTTON_UPDATE_BADGE.getValue() && ModMenu.areModUpdatesAvailable()) {
-			UpdateAvailableBadge.renderBadge(DrawContext,
+			UpdateAvailableBadge.renderBadge(context,
 				this.width + this.getX() - 16,
 				this.height / 2 + this.getY() - 4
 			);

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateAvailableBadge.java
@@ -1,20 +1,13 @@
 package com.terraformersmc.modmenu.gui.widget;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.Util;
 
 public class UpdateAvailableBadge {
 	private static final Identifier UPDATE_ICON = Identifier.ofVanilla("icon/trial_available");
 
-	public static void renderBadge(DrawContext DrawContext, int x, int y) {
-		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-		int animOffset = 0;
-		if ((Util.getMeasuringTimeMs() / 800L & 1L) == 1L) {
-			animOffset = 8;
-		}
-		DrawContext.drawGuiTexture(RenderLayer::getGuiTextured, UPDATE_ICON, x, y, 8, 8);
+	public static void renderBadge(DrawContext context, int x, int y) {
+		context.drawGuiTexture(RenderLayer::getGuiTextured, UPDATE_ICON, x, y, 8, 8);
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateCheckerTexturedButtonWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/UpdateCheckerTexturedButtonWidget.java
@@ -27,10 +27,10 @@ public class UpdateCheckerTexturedButtonWidget extends LegacyTexturedButtonWidge
 	}
 
 	@Override
-	public void renderWidget(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		super.renderWidget(DrawContext, mouseX, mouseY, delta);
+	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+		super.renderWidget(context, mouseX, mouseY, delta);
 		if (ModMenuConfig.BUTTON_UPDATE_BADGE.getValue() && ModMenu.areModUpdatesAvailable()) {
-			UpdateAvailableBadge.renderBadge(DrawContext, this.getX() + this.width - 5, this.getY() - 3);
+			UpdateAvailableBadge.renderBadge(context, this.getX() + this.width - 5, this.getY() - 3);
 		}
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ChildEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ChildEntry.java
@@ -17,7 +17,7 @@ public class ChildEntry extends ModListEntry {
 
 	@Override
 	public void render(
-		DrawContext DrawContext,
+		DrawContext context,
 		int index,
 		int y,
 		int x,
@@ -28,11 +28,11 @@ public class ChildEntry extends ModListEntry {
 		boolean isSelected,
 		float delta
 	) {
-		super.render(DrawContext, index, y, x, rowWidth, rowHeight, mouseX, mouseY, isSelected, delta);
+		super.render(context, index, y, x, rowWidth, rowHeight, mouseX, mouseY, isSelected, delta);
 		x += 4;
 		int color = 0xFFA0A0A0;
-		DrawContext.fill(x, y - 2, x + 1, y + (bottomChild ? rowHeight / 2 : rowHeight + 2), color);
-		DrawContext.fill(x, y + rowHeight / 2, x + 7, y + rowHeight / 2 + 1, color);
+		context.fill(x, y - 2, x + 1, y + (bottomChild ? rowHeight / 2 : rowHeight + 2), color);
+		context.fill(x, y + rowHeight / 2, x + 7, y + rowHeight / 2 + 1, color);
 	}
 
 	@Override

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ModListEntry.java
@@ -1,6 +1,5 @@
 package com.terraformersmc.modmenu.gui.widget.entries;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.widget.ModListWidget;
@@ -50,7 +49,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 
 	@Override
 	public void render(
-		DrawContext DrawContext,
+		DrawContext context,
 		int index,
 		int y,
 		int x,
@@ -66,23 +65,13 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		int iconSize = ModMenuConfig.COMPACT_LIST.getValue() ? COMPACT_ICON_SIZE : FULL_ICON_SIZE;
 		String modId = mod.getId();
 		if ("java".equals(modId)) {
-			DrawingUtil.drawRandomVersionBackground(mod, DrawContext, x, y, iconSize, iconSize);
+			DrawingUtil.drawRandomVersionBackground(mod, context, x, y, iconSize, iconSize);
 		}
-		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-		RenderSystem.enableBlend();
-		DrawContext.drawTexture(RenderLayer::getGuiTextured, this.getIconTexture(), x, y, 0.0F, 0.0F, iconSize, iconSize, iconSize, iconSize);
-		RenderSystem.disableBlend();
+		context.drawTexture(RenderLayer::getGuiTextured, this.getIconTexture(), x, y, 0.0F, 0.0F, iconSize, iconSize, iconSize, iconSize);
 		Text name = Text.literal(mod.getTranslatedName());
-		StringVisitable trimmedName = name;
-		int maxNameWidth = rowWidth - iconSize - 3;
 		TextRenderer font = this.client.textRenderer;
-		if (font.getWidth(name) > maxNameWidth) {
-			StringVisitable ellipsis = StringVisitable.plain("...");
-			trimmedName = StringVisitable.concat(font.trimToWidth(name, maxNameWidth - font.getWidth(ellipsis)),
-				ellipsis
-			);
-		}
-		DrawContext.drawText(font,
+		StringVisitable trimmedName = DrawingUtil.getTrimmedName(name, rowWidth - iconSize - 3, font);
+		context.drawText(font,
 			Language.getInstance().reorder(trimmedName),
 			x + iconSize + 3,
 			y + 1,
@@ -92,7 +81,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 		var updateBadgeXOffset = 0;
 		if (ModMenuConfig.UPDATE_CHECKER.getValue() && !ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue()
 			.contains(modId) && (mod.hasUpdate() || mod.getChildHasUpdate())) {
-			UpdateAvailableBadge.renderBadge(DrawContext, x + iconSize + 3 + font.getWidth(name) + 2, y);
+			UpdateAvailableBadge.renderBadge(context, x + iconSize + 3 + font.getWidth(name) + 2, y);
 			updateBadgeXOffset = 11;
 		}
 		if (!ModMenuConfig.HIDE_BADGES.getValue()) {
@@ -101,11 +90,11 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 				x + rowWidth,
 				mod,
 				list.getParent()
-			).draw(DrawContext, mouseX, mouseY);
+			).draw(context, mouseX, mouseY);
 		}
 		if (!ModMenuConfig.COMPACT_LIST.getValue()) {
 			String summary = mod.getSummary();
-			DrawingUtil.drawWrappedString(DrawContext,
+			DrawingUtil.drawWrappedString(context,
 				summary,
 				(x + iconSize + 3 + 4),
 				(y + client.textRenderer.fontHeight + 2),
@@ -114,7 +103,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 				0x808080
 			);
 		} else {
-			DrawingUtil.drawWrappedString(DrawContext,
+			DrawingUtil.drawWrappedString(context,
 				mod.getPrefixedVersion(),
 				(x + iconSize + 3),
 				(y + client.textRenderer.fontHeight + 2),
@@ -130,10 +119,10 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 				(int) (256 / (FULL_ICON_SIZE / (double) COMPACT_ICON_SIZE)) :
 				256;
 			if (this.client.options.getTouchscreen().getValue() || hovered) {
-				DrawContext.fill(x, y, x + iconSize, y + iconSize, -1601138544);
+				context.fill(x, y, x + iconSize, y + iconSize, -1601138544);
 				boolean hoveringIcon = mouseX - x < iconSize;
 				if (this.list.getParent().modScreenErrors.containsKey(modId)) {
-					DrawContext.drawGuiTexture(RenderLayer::getGuiTextured, hoveringIcon ? ERROR_HIGHLIGHTED_ICON : ERROR_ICON,
+					context.drawGuiTexture(RenderLayer::getGuiTextured, hoveringIcon ? ERROR_HIGHLIGHTED_ICON : ERROR_ICON,
 						x,
 						y,
 						iconSize,
@@ -149,7 +138,7 @@ public class ModListEntry extends AlwaysSelectedEntryListWidget.Entry<ModListEnt
 					}
 				} else {
 					int v = hoveringIcon ? iconSize : 0;
-					DrawContext.drawTexture(RenderLayer::getGuiTextured, MOD_CONFIGURATION_ICON,
+					context.drawTexture(RenderLayer::getGuiTextured, MOD_CONFIGURATION_ICON,
 						x,
 						y,
 						0.0F,

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
@@ -1,6 +1,5 @@
 package com.terraformersmc.modmenu.gui.widget.entries;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.widget.ModListWidget;
@@ -32,7 +31,7 @@ public class ParentEntry extends ModListEntry {
 
 	@Override
 	public void render(
-		DrawContext DrawContext,
+		DrawContext context,
 		int index,
 		int y,
 		int x,
@@ -43,7 +42,7 @@ public class ParentEntry extends ModListEntry {
 		boolean isSelected,
 		float delta
 	) {
-		super.render(DrawContext, index, y, x, rowWidth, rowHeight, mouseX, mouseY, isSelected, delta);
+		super.render(context, index, y, x, rowWidth, rowHeight, mouseX, mouseY, isSelected, delta);
 		TextRenderer font = client.textRenderer;
 		int childrenBadgeHeight = font.fontHeight;
 		int childrenBadgeWidth = font.fontHeight;
@@ -60,37 +59,37 @@ public class ParentEntry extends ModListEntry {
 		int childrenBadgeY = y + iconSize - childrenBadgeHeight;
 		int childrenOutlineColor = 0xff107454;
 		int childrenFillColor = 0xff093929;
-		DrawContext.fill(childrenBadgeX + 1,
+		context.fill(childrenBadgeX + 1,
 			childrenBadgeY,
 			childrenBadgeX + childrenBadgeWidth - 1,
 			childrenBadgeY + 1,
 			childrenOutlineColor
 		);
-		DrawContext.fill(childrenBadgeX,
+		context.fill(childrenBadgeX,
 			childrenBadgeY + 1,
 			childrenBadgeX + 1,
 			childrenBadgeY + childrenBadgeHeight - 1,
 			childrenOutlineColor
 		);
-		DrawContext.fill(childrenBadgeX + childrenBadgeWidth - 1,
+		context.fill(childrenBadgeX + childrenBadgeWidth - 1,
 			childrenBadgeY + 1,
 			childrenBadgeX + childrenBadgeWidth,
 			childrenBadgeY + childrenBadgeHeight - 1,
 			childrenOutlineColor
 		);
-		DrawContext.fill(childrenBadgeX + 1,
+		context.fill(childrenBadgeX + 1,
 			childrenBadgeY + 1,
 			childrenBadgeX + childrenBadgeWidth - 1,
 			childrenBadgeY + childrenBadgeHeight - 1,
 			childrenFillColor
 		);
-		DrawContext.fill(childrenBadgeX + 1,
+		context.fill(childrenBadgeX + 1,
 			childrenBadgeY + childrenBadgeHeight - 1,
 			childrenBadgeX + childrenBadgeWidth - 1,
 			childrenBadgeY + childrenBadgeHeight,
 			childrenOutlineColor
 		);
-		DrawContext.drawText(font,
+		context.drawText(font,
 			str.asOrderedText(),
 			(int) (childrenBadgeX + (float) childrenBadgeWidth / 2 - (float) childrenWidth / 2),
 			childrenBadgeY + 1,
@@ -99,11 +98,10 @@ public class ParentEntry extends ModListEntry {
 		);
 		this.hoveringIcon = mouseX >= x - 1 && mouseX <= x - 1 + iconSize && mouseY >= y - 1 && mouseY <= y - 1 + iconSize;
 		if (isMouseOver(mouseX, mouseY)) {
-			DrawContext.fill(x, y, x + iconSize, y + iconSize, 0xA0909090);
+			context.fill(x, y, x + iconSize, y + iconSize, 0xA0909090);
 			int xOffset = list.getParent().showModChildren.contains(getMod().getId()) ? iconSize : 0;
 			int yOffset = hoveringIcon ? iconSize : 0;
-			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-			DrawContext.drawTexture(RenderLayer::getGuiTextured, PARENT_MOD_TEXTURE,
+			context.drawTexture(RenderLayer::getGuiTextured, PARENT_MOD_TEXTURE,
 				x,
 				y,
 				xOffset,

--- a/src/main/java/com/terraformersmc/modmenu/util/DrawingUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/DrawingUtil.java
@@ -1,11 +1,11 @@
 package com.terraformersmc.modmenu.util;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.StringVisitable;
@@ -21,9 +21,11 @@ import java.util.Random;
 public class DrawingUtil {
 	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
 
+	private static final StringVisitable ELLIPSIS = StringVisitable.plain("...");
+
 	public static void drawRandomVersionBackground(
 		Mod mod,
-		DrawContext DrawContext,
+		DrawContext context,
 		int x,
 		int y,
 		int width,
@@ -35,12 +37,11 @@ public class DrawingUtil {
 		if (!ModMenuConfig.RANDOM_JAVA_COLORS.getValue()) {
 			color = 0xFFDD5656;
 		}
-		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-		DrawContext.fill(x, y, x + width, y + height, color);
+		context.fill(x, y, x + width, y + height, color);
 	}
 
 	public static void drawWrappedString(
-		DrawContext DrawContext,
+		DrawContext context,
 		String string,
 		int x,
 		int y,
@@ -59,7 +60,7 @@ public class DrawingUtil {
 			}
 			StringVisitable renderable = strings.get(i);
 			if (i == lines - 1 && strings.size() > lines) {
-				renderable = StringVisitable.concat(strings.get(i), StringVisitable.plain("..."));
+				renderable = StringVisitable.concat(strings.get(i), ELLIPSIS);
 			}
 			OrderedText line = Language.getInstance().reorder(renderable);
 			int x1 = x;
@@ -67,12 +68,12 @@ public class DrawingUtil {
 				int width = CLIENT.textRenderer.getWidth(line);
 				x1 += (float) (wrapWidth - width);
 			}
-			DrawContext.drawText(CLIENT.textRenderer, line, x1, y + i * CLIENT.textRenderer.fontHeight, color, true);
+			context.drawText(CLIENT.textRenderer, line, x1, y + i * CLIENT.textRenderer.fontHeight, color, true);
 		}
 	}
 
 	public static void drawBadge(
-		DrawContext DrawContext,
+		DrawContext context,
 		int x,
 		int y,
 		int tagWidth,
@@ -81,22 +82,33 @@ public class DrawingUtil {
 		int fillColor,
 		int textColor
 	) {
-		DrawContext.fill(x + 1, y - 1, x + tagWidth, y, outlineColor);
-		DrawContext.fill(x, y, x + 1, y + CLIENT.textRenderer.fontHeight, outlineColor);
-		DrawContext.fill(x + 1,
+		context.fill(x + 1, y - 1, x + tagWidth, y, outlineColor);
+		context.fill(x, y, x + 1, y + CLIENT.textRenderer.fontHeight, outlineColor);
+		context.fill(x + 1,
 			y + 1 + CLIENT.textRenderer.fontHeight - 1,
 			x + tagWidth,
 			y + CLIENT.textRenderer.fontHeight + 1,
 			outlineColor
 		);
-		DrawContext.fill(x + tagWidth, y, x + tagWidth + 1, y + CLIENT.textRenderer.fontHeight, outlineColor);
-		DrawContext.fill(x + 1, y, x + tagWidth, y + CLIENT.textRenderer.fontHeight, fillColor);
-		DrawContext.drawText(CLIENT.textRenderer,
+		context.fill(x + tagWidth, y, x + tagWidth + 1, y + CLIENT.textRenderer.fontHeight, outlineColor);
+		context.fill(x + 1, y, x + tagWidth, y + CLIENT.textRenderer.fontHeight, fillColor);
+		context.drawText(CLIENT.textRenderer,
 			text,
 			(int) (x + 1 + (tagWidth - CLIENT.textRenderer.getWidth(text)) / (float) 2),
 			y + 1,
 			textColor,
 			false
 		);
+	}
+
+	public static StringVisitable getTrimmedName(StringVisitable name, int maxWidth, TextRenderer textRenderer) {
+		if (textRenderer.getWidth(name) > maxWidth) {
+			int ellipsisWidth = textRenderer.getWidth(ELLIPSIS);
+
+			StringVisitable trimmed = textRenderer.trimToWidth(name, maxWidth - ellipsisWidth);
+			return StringVisitable.concat(trimmed, ELLIPSIS);
+		}
+
+		return name;
 	}
 }

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModBadgeRenderer.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModBadgeRenderer.java
@@ -23,15 +23,15 @@ public class ModBadgeRenderer {
 		this.client = MinecraftClient.getInstance();
 	}
 
-	public void draw(DrawContext DrawContext, int mouseX, int mouseY) {
+	public void draw(DrawContext context, int mouseX, int mouseY) {
 		this.badgeX = startX;
 		this.badgeY = startY;
 		Set<Mod.Badge> badges = mod.getBadges();
-		badges.forEach(badge -> drawBadge(DrawContext, badge, mouseX, mouseY));
+		badges.forEach(badge -> drawBadge(context, badge, mouseX, mouseY));
 	}
 
-	public void drawBadge(DrawContext DrawContext, Mod.Badge badge, int mouseX, int mouseY) {
-		this.drawBadge(DrawContext,
+	public void drawBadge(DrawContext context, Mod.Badge badge, int mouseX, int mouseY) {
+		this.drawBadge(context,
 			badge.getText().asOrderedText(),
 			badge.getOutlineColor(),
 			badge.getFillColor(),
@@ -41,7 +41,7 @@ public class ModBadgeRenderer {
 	}
 
 	public void drawBadge(
-		DrawContext DrawContext,
+		DrawContext context,
 		OrderedText text,
 		int outlineColor,
 		int fillColor,
@@ -50,7 +50,7 @@ public class ModBadgeRenderer {
 	) {
 		int width = client.textRenderer.getWidth(text) + 6;
 		if (badgeX + width < badgeMax) {
-			DrawingUtil.drawBadge(DrawContext, badgeX, badgeY, width, text, outlineColor, fillColor, 0xCACACA);
+			DrawingUtil.drawBadge(context, badgeX, badgeY, width, text, outlineColor, fillColor, 0xCACACA);
 			badgeX += width + 3;
 		}
 	}


### PR DESCRIPTION
This pull request introduces some minor refactors to rendering that remove all references to `RenderSystem` and `ShaderProgramKeys`, the latter of which is removed in [Minecraft snapshot 25w07a](https://www.minecraft.net/en-us/article/minecraft-snapshot-25w07a). This change can also be backported to other version branches.