### PR TITLE
Remove redundant stack trace printing for icon errors

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricIconHandler.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricIconHandler.java
@@ -43,15 +43,14 @@ public class FabricIconHandler implements Closeable {
 			if (e.getMessage().equals("Must be square icon")) {
 				LOGGER.error("Mod icon must be a square for icon source {}: {}",
 					iconSource.getMetadata().getId(),
-					iconPath,
-					e
+					iconPath
 				);
 			}
 
 			return null;
 		} catch (Throwable t) {
 			if (!iconPath.equals("assets/" + iconSource.getMetadata().getId() + "/icon.png")) {
-				LOGGER.error("Invalid mod icon for icon source {}: {}", iconSource.getMetadata().getId(), iconPath, t);
+				LOGGER.error("Invalid mod icon for icon source {}: {}", iconSource.getMetadata().getId(), iconPath);
 			}
 			return null;
 		}


### PR DESCRIPTION
I'm often in the situation where I'm developing a new mod that doesn't have an icon yet. I use Mod Menu to access my config file, and it prints a large stack trace twice. Once when entering, and once when exiting.

Since there is already a complete error line in red, which is acceptable to be shown I think, there is no need for a multi-line stack trace after that.

I've removed it for the non-square icon error as well, since that feels redundant too. But I can re-add that, let me know.

Thanks for the great mod!