### PR TITLE
Support keeping scroll positions

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -515,40 +515,38 @@ public class ModsScreen extends Screen {
 	}
 
 	public void updateSelectedEntry(ModListEntry entry) {
-		if (entry != null) {
-			this.selected = entry;
-			String modId = selected.getMod().getId();
-
-			if (this.configureButton != null) {
-
-				this.configureButton.active = getModHasConfigScreen(modId);
-				this.configureButton.visible =
-					selected != null && getModHasConfigScreen(modId) || modScreenErrors.containsKey(modId);
-
-				if (modScreenErrors.containsKey(modId)) {
-					Throwable e = modScreenErrors.get(modId);
-					this.configureButton.setTooltip(Tooltip.of(ModMenuScreenTexts.configureError(modId, e)));
-				} else {
-					this.configureButton.setTooltip(Tooltip.of(ModMenuScreenTexts.CONFIGURE));
-				}
-			}
-
-			var isMinecraft = modId.equals("minecraft");
-
-			if (isMinecraft) {
-				this.websiteButton.setMessage(SEND_FEEDBACK_TEXT);
-				this.issuesButton.setMessage(REPORT_BUGS_TEXT);
-			} else {
-				this.websiteButton.setMessage(ModMenuScreenTexts.WEBSITE);
-				this.issuesButton.setMessage(ModMenuScreenTexts.ISSUES);
-			}
-
-			this.websiteButton.visible = true;
-			this.websiteButton.active = isMinecraft || selected.getMod().getWebsite() != null;
-
-			this.issuesButton.visible = true;
-			this.issuesButton.active = isMinecraft || selected.getMod().getIssueTracker() != null;
+		if (entry == null) {
+			return;
 		}
+
+		this.selected = entry;
+		String modId = selected.getMod().getId();
+
+		this.descriptionListWidget.updateSelectedModIfRequired(selected.getMod());
+
+		if (this.configureButton != null) {
+
+			this.configureButton.active = getModHasConfigScreen(modId);
+			this.configureButton.visible =
+				selected != null && getModHasConfigScreen(modId) || modScreenErrors.containsKey(modId);
+
+			if (modScreenErrors.containsKey(modId)) {
+				Throwable e = modScreenErrors.get(modId);
+				this.configureButton.setTooltip(Tooltip.of(ModMenuScreenTexts.configureError(modId, e)));
+			} else {
+				this.configureButton.setTooltip(Tooltip.of(ModMenuScreenTexts.CONFIGURE));
+			}
+		}
+
+		boolean isMinecraft = modId.equals("minecraft");
+		this.websiteButton.setMessage(isMinecraft ? SEND_FEEDBACK_TEXT : ModMenuScreenTexts.WEBSITE);
+		this.issuesButton.setMessage(isMinecraft ? REPORT_BUGS_TEXT : ModMenuScreenTexts.ISSUES);
+
+		this.websiteButton.visible = true;
+		this.websiteButton.active = isMinecraft || selected.getMod().getWebsite() != null;
+
+		this.issuesButton.visible = true;
+		this.issuesButton.active = isMinecraft || selected.getMod().getIssueTracker() != null;
 	}
 
 	public double getScrollPercent() {

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -241,6 +241,7 @@ public class ModsScreen extends Screen {
 			this.height - RIGHT_PANE_Y - 96,
 			RIGHT_PANE_Y + 60,
 			textRenderer.fontHeight + 1,
+			this.descriptionListWidget,
 			this
 		);
 		this.descriptionListWidget.setX(this.rightPaneX);

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -256,7 +256,7 @@ public class ModsScreen extends Screen {
 		}).position(this.width / 2 + 4, this.height - 28).size(150, 20).build();
 
 		// Initialize data
-		modList.reloadFilters();
+		modList.finalizeInit();
 		this.setFilterOptionsShown(this.keepFilterOptionsShown && this.filterOptionsShown);
 
 		// Add children

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -51,7 +51,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 	private final ModsScreen parent;
 	private final TextRenderer textRenderer;
-	private ModListEntry lastSelected = null;
+	private Mod lastSelectedMod = null;
 
 	public DescriptionListWidget(
 		MinecraftClient client,
@@ -59,11 +59,19 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		int height,
 		int y,
 		int itemHeight,
+		DescriptionListWidget copyFrom,
 		ModsScreen parent
 	) {
 		super(client, width, height, y, itemHeight);
 		this.parent = parent;
 		this.textRenderer = client.textRenderer;
+
+		if(copyFrom != null) {
+			this.lastSelectedMod = copyFrom.lastSelectedMod;
+			clearEntries();
+			buildUIFromLastSelected();
+			setScrollY(copyFrom.getScrollY());
+		}
 	}
 
 	@Override
@@ -87,179 +95,185 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		builder.put(NarrationPart.TITLE, mod.getTranslatedName() + " " + mod.getPrefixedVersion());
 	}
 
-	@Override
-	public void renderList(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		ModListEntry selectedEntry = parent.getSelectedEntry();
-		if (selectedEntry != lastSelected) {
-			lastSelected = selectedEntry;
-			clearEntries();
-			setScrollY(-Double.MAX_VALUE);
-			if (lastSelected != null) {
-				DescriptionEntry emptyEntry = new DescriptionEntry(OrderedText.EMPTY);
-				int wrapWidth = getRowWidth() - 5;
+	private void buildUIFromLastSelected() {
+		if (lastSelectedMod == null) {
+			return;
+		}
 
-				Mod mod = lastSelected.getMod();
-				Text description = mod.getFormattedDescription();
-				if (!description.getString().isEmpty()) {
-					for (OrderedText line : textRenderer.wrapLines(description, wrapWidth)) {
-						children().add(new DescriptionEntry(line));
+		DescriptionEntry emptyEntry = new DescriptionEntry(OrderedText.EMPTY);
+		int wrapWidth = getRowWidth() - 5;
+
+		Mod mod = lastSelectedMod;
+		Text description = mod.getFormattedDescription();
+		if (!description.getString().isEmpty()) {
+			for (OrderedText line : textRenderer.wrapLines(description, wrapWidth)) {
+				children().add(new DescriptionEntry(line));
+			}
+		}
+
+		if (ModMenuConfig.UPDATE_CHECKER.getValue() && !ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue()
+			.contains(mod.getId())) {
+			UpdateInfo updateInfo = mod.getUpdateInfo();
+			if (updateInfo != null && updateInfo.isUpdateAvailable()) {
+				children().add(emptyEntry);
+
+				int index = 0;
+				for (OrderedText line : textRenderer.wrapLines(HAS_UPDATE_TEXT, wrapWidth - 11)) {
+					DescriptionEntry entry = new DescriptionEntry(line);
+					if (index == 0) {
+						entry.setUpdateTextEntry();
 					}
+
+					children().add(entry);
+					index += 1;
 				}
 
-				if (ModMenuConfig.UPDATE_CHECKER.getValue() && !ModMenuConfig.DISABLE_UPDATE_CHECKER.getValue()
-					.contains(mod.getId())) {
-					UpdateInfo updateInfo = mod.getUpdateInfo();
-					if (updateInfo != null && updateInfo.isUpdateAvailable()) {
-						children().add(emptyEntry);
-
-						int index = 0;
-						for (OrderedText line : textRenderer.wrapLines(HAS_UPDATE_TEXT, wrapWidth - 11)) {
-							DescriptionEntry entry = new DescriptionEntry(line);
-							if (index == 0) {
-								entry.setUpdateTextEntry();
-							}
-
-							children().add(entry);
-							index += 1;
-						}
-
-						for (OrderedText line : textRenderer.wrapLines(EXPERIMENTAL_TEXT, wrapWidth - 16)) {
-							children().add(new DescriptionEntry(line, 8));
-						}
-
-
-						Text updateMessage = updateInfo.getUpdateMessage();
-						String downloadLink = updateInfo.getDownloadLink();
-						if (updateMessage == null) {
-							updateMessage = DOWNLOAD_TEXT;
-						} else {
-							if (downloadLink != null) {
-								updateMessage = updateMessage.copy()
-									.formatted(Formatting.BLUE)
-									.formatted(Formatting.UNDERLINE);
-							}
-						}
-						for (OrderedText line : textRenderer.wrapLines(updateMessage, wrapWidth - 16)) {
-							if (downloadLink != null) {
-								children().add(new LinkEntry(line, downloadLink, 8));
-							} else {
-								children().add(new DescriptionEntry(line, 8));
-
-							}
-						}
-					}
-					if (mod.getChildHasUpdate()) {
-						children().add(emptyEntry);
-
-						int index = 0;
-						for (OrderedText line : textRenderer.wrapLines(CHILD_HAS_UPDATE_TEXT, wrapWidth - 11)) {
-							DescriptionEntry entry = new DescriptionEntry(line);
-							if (index == 0) {
-								entry.setUpdateTextEntry();
-							}
-
-							children().add(entry);
-							index += 1;
-						}
-					}
+				for (OrderedText line : textRenderer.wrapLines(EXPERIMENTAL_TEXT, wrapWidth - 16)) {
+					children().add(new DescriptionEntry(line, 8));
 				}
 
-				Map<String, String> links = mod.getLinks();
-				String sourceLink = mod.getSource();
-				if ((!links.isEmpty() || sourceLink != null) && !ModMenuConfig.HIDE_MOD_LINKS.getValue()) {
+
+				Text updateMessage = updateInfo.getUpdateMessage();
+				String downloadLink = updateInfo.getDownloadLink();
+				if (updateMessage == null) {
+					updateMessage = DOWNLOAD_TEXT;
+				} else {
+					if (downloadLink != null) {
+						updateMessage = updateMessage.copy()
+							.formatted(Formatting.BLUE)
+							.formatted(Formatting.UNDERLINE);
+					}
+				}
+				for (OrderedText line : textRenderer.wrapLines(updateMessage, wrapWidth - 16)) {
+					if (downloadLink != null) {
+						children().add(new LinkEntry(line, downloadLink, 8));
+					} else {
+						children().add(new DescriptionEntry(line, 8));
+
+					}
+				}
+			}
+			if (mod.getChildHasUpdate()) {
+				children().add(emptyEntry);
+
+				int index = 0;
+				for (OrderedText line : textRenderer.wrapLines(CHILD_HAS_UPDATE_TEXT, wrapWidth - 11)) {
+					DescriptionEntry entry = new DescriptionEntry(line);
+					if (index == 0) {
+						entry.setUpdateTextEntry();
+					}
+
+					children().add(entry);
+					index += 1;
+				}
+			}
+		}
+
+		Map<String, String> links = mod.getLinks();
+		String sourceLink = mod.getSource();
+		if ((!links.isEmpty() || sourceLink != null) && !ModMenuConfig.HIDE_MOD_LINKS.getValue()) {
+			children().add(emptyEntry);
+
+			for (OrderedText line : textRenderer.wrapLines(LINKS_TEXT, wrapWidth)) {
+				children().add(new DescriptionEntry(line));
+			}
+
+			if (sourceLink != null) {
+				int indent = 8;
+				for (OrderedText line : textRenderer.wrapLines(SOURCE_TEXT, wrapWidth - 16)) {
+					children().add(new LinkEntry(line, sourceLink, indent));
+					indent = 16;
+				}
+			}
+
+			links.forEach((key, value) -> {
+				int indent = 8;
+				for (OrderedText line : textRenderer.wrapLines(Text.translatable(key)
+						.formatted(Formatting.BLUE)
+						.formatted(Formatting.UNDERLINE),
+					wrapWidth - 16
+				)) {
+					children().add(new LinkEntry(line, value, indent));
+					indent = 16;
+				}
+			});
+		}
+
+		Set<String> licenses = mod.getLicense();
+		if (!ModMenuConfig.HIDE_MOD_LICENSE.getValue() && !licenses.isEmpty()) {
+			children().add(emptyEntry);
+
+			for (OrderedText line : textRenderer.wrapLines(LICENSE_TEXT, wrapWidth)) {
+				children().add(new DescriptionEntry(line));
+			}
+
+			for (String license : licenses) {
+				int indent = 8;
+				for (OrderedText line : textRenderer.wrapLines(Text.literal(license), wrapWidth - 16)) {
+					children().add(new DescriptionEntry(line, indent));
+					indent = 16;
+				}
+			}
+		}
+
+		if (!ModMenuConfig.HIDE_MOD_CREDITS.getValue()) {
+			if ("minecraft".equals(mod.getId())) {
+				children().add(emptyEntry);
+
+				for (OrderedText line : textRenderer.wrapLines(VIEW_CREDITS_TEXT, wrapWidth)) {
+					children().add(new MojangCreditsEntry(line));
+				}
+			} else if (!"java".equals(mod.getId())) {
+				var credits = mod.getCredits();
+
+				if (!credits.isEmpty()) {
 					children().add(emptyEntry);
 
-					for (OrderedText line : textRenderer.wrapLines(LINKS_TEXT, wrapWidth)) {
+					for (OrderedText line : textRenderer.wrapLines(CREDITS_TEXT, wrapWidth)) {
 						children().add(new DescriptionEntry(line));
 					}
 
-					if (sourceLink != null) {
-						int indent = 8;
-						for (OrderedText line : textRenderer.wrapLines(SOURCE_TEXT, wrapWidth - 16)) {
-							children().add(new LinkEntry(line, sourceLink, indent));
-							indent = 16;
-						}
-					}
+					var iterator = credits.entrySet().iterator();
 
-					links.forEach((key, value) -> {
+					while (iterator.hasNext()) {
 						int indent = 8;
-						for (OrderedText line : textRenderer.wrapLines(Text.translatable(key)
-								.formatted(Formatting.BLUE)
-								.formatted(Formatting.UNDERLINE),
+
+						var role = iterator.next();
+						var roleName = role.getKey();
+
+						for (var line : textRenderer.wrapLines(this.creditsRoleText(roleName),
 							wrapWidth - 16
 						)) {
-							children().add(new LinkEntry(line, value, indent));
-							indent = 16;
-						}
-					});
-				}
-
-				Set<String> licenses = mod.getLicense();
-				if (!ModMenuConfig.HIDE_MOD_LICENSE.getValue() && !licenses.isEmpty()) {
-					children().add(emptyEntry);
-
-					for (OrderedText line : textRenderer.wrapLines(LICENSE_TEXT, wrapWidth)) {
-						children().add(new DescriptionEntry(line));
-					}
-
-					for (String license : licenses) {
-						int indent = 8;
-						for (OrderedText line : textRenderer.wrapLines(Text.literal(license), wrapWidth - 16)) {
 							children().add(new DescriptionEntry(line, indent));
 							indent = 16;
 						}
-					}
-				}
 
-				if (!ModMenuConfig.HIDE_MOD_CREDITS.getValue()) {
-					if ("minecraft".equals(mod.getId())) {
-						children().add(emptyEntry);
+						for (var contributor : role.getValue()) {
+							indent = 16;
 
-						for (OrderedText line : textRenderer.wrapLines(VIEW_CREDITS_TEXT, wrapWidth)) {
-							children().add(new MojangCreditsEntry(line));
+							for (var line : textRenderer.wrapLines(Text.literal(contributor), wrapWidth - 24)) {
+								children().add(new DescriptionEntry(line, indent));
+								indent = 24;
+							}
 						}
-					} else if (!"java".equals(mod.getId())) {
-						var credits = mod.getCredits();
 
-						if (!credits.isEmpty()) {
+						if (iterator.hasNext()) {
 							children().add(emptyEntry);
-
-							for (OrderedText line : textRenderer.wrapLines(CREDITS_TEXT, wrapWidth)) {
-								children().add(new DescriptionEntry(line));
-							}
-
-							var iterator = credits.entrySet().iterator();
-
-							while (iterator.hasNext()) {
-								int indent = 8;
-
-								var role = iterator.next();
-								var roleName = role.getKey();
-
-								for (var line : textRenderer.wrapLines(this.creditsRoleText(roleName),
-									wrapWidth - 16
-								)) {
-									children().add(new DescriptionEntry(line, indent));
-									indent = 16;
-								}
-
-								for (var contributor : role.getValue()) {
-									indent = 16;
-
-									for (var line : textRenderer.wrapLines(Text.literal(contributor), wrapWidth - 24)) {
-										children().add(new DescriptionEntry(line, indent));
-										indent = 24;
-									}
-								}
-
-								if (iterator.hasNext()) {
-									children().add(emptyEntry);
-								}
-							}
 						}
 					}
 				}
 			}
+		}
+	}
+
+	@Override
+	public void renderList(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
+		ModListEntry selectedEntry = parent.getSelectedEntry();
+		if (selectedEntry.getMod() != lastSelectedMod) {
+			lastSelectedMod = selectedEntry.getMod();
+			clearEntries();
+			setScrollY(-Double.MAX_VALUE);
+			buildUIFromLastSelected();
 		}
 
 		Tessellator tessellator = Tessellator.getInstance();

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
-import com.terraformersmc.modmenu.gui.widget.entries.ModListEntry;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
@@ -51,7 +50,7 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 	private final ModsScreen parent;
 	private final TextRenderer textRenderer;
-	private Mod lastSelectedMod = null;
+	private Mod selectedMod = null;
 
 	public DescriptionListWidget(
 		MinecraftClient client,
@@ -67,10 +66,12 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		this.textRenderer = client.textRenderer;
 
 		if(copyFrom != null) {
-			this.lastSelectedMod = copyFrom.lastSelectedMod;
-			clearEntries();
-			buildUIFromLastSelected();
+			updateSelectedModIfRequired(copyFrom.selectedMod);
 			setScrollY(copyFrom.getScrollY());
+		}
+
+		if(parent.getSelectedEntry() != null) {
+			updateSelectedModIfRequired(parent.getSelectedEntry().getMod());
 		}
 	}
 
@@ -91,19 +92,22 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 
 	@Override
 	public void appendClickableNarrations(NarrationMessageBuilder builder) {
-		Mod mod = parent.getSelectedEntry().getMod();
-		builder.put(NarrationPart.TITLE, mod.getTranslatedName() + " " + mod.getPrefixedVersion());
+		if(selectedMod != null) {
+			builder.put(
+				NarrationPart.TITLE,
+				selectedMod.getTranslatedName() + " " + selectedMod.getPrefixedVersion());
+		}
 	}
 
-	private void buildUIFromLastSelected() {
-		if (lastSelectedMod == null) {
+	private void rebuildUI() {
+		if (selectedMod == null) {
 			return;
 		}
 
 		DescriptionEntry emptyEntry = new DescriptionEntry(OrderedText.EMPTY);
 		int wrapWidth = getRowWidth() - 5;
 
-		Mod mod = lastSelectedMod;
+		Mod mod = selectedMod;
 		Text description = mod.getFormattedDescription();
 		if (!description.getString().isEmpty()) {
 			for (OrderedText line : textRenderer.wrapLines(description, wrapWidth)) {
@@ -266,16 +270,17 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 		}
 	}
 
-	@Override
-	public void renderList(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
-		ModListEntry selectedEntry = parent.getSelectedEntry();
-		if (selectedEntry.getMod() != lastSelectedMod) {
-			lastSelectedMod = selectedEntry.getMod();
+	public void updateSelectedModIfRequired(Mod mod) {
+		if (mod != selectedMod) {
+			selectedMod = mod;
 			clearEntries();
 			setScrollY(-Double.MAX_VALUE);
-			buildUIFromLastSelected();
+			rebuildUI();
 		}
+	}
 
+	@Override
+	public void renderList(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferBuilder;
 		BuiltBuffer builtBuffer;

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -33,6 +33,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 	private String selectedModId = null;
 	//private boolean scrolling;
 	private final FabricIconHandler iconHandler = new FabricIconHandler();
+	private Double restoreScrollY = null;
 
 	public ModListWidget(
 		MinecraftClient client,
@@ -47,6 +48,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 		this.parent = parent;
 		if (list != null) {
 			this.mods = list.mods;
+			this.restoreScrollY = list.getScrollY();
 		}
 	}
 
@@ -118,6 +120,14 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 	protected ModListEntry remove(int index) {
 		addedMods.remove(getEntry(index).mod);
 		return super.remove(index);
+	}
+
+	public void finalizeInit() {
+		reloadFilters();
+		if(restoreScrollY != null) {
+			setScrollY(restoreScrollY);
+			restoreScrollY = null;
+		}
 	}
 
 	public void reloadFilters() {


### PR DESCRIPTION
Fixes #485 

Currently when clicking on something (e.g. "Website" Button) in the mods screen, all scroll positions get reset:

https://github.com/user-attachments/assets/35b2b753-7c3d-4e85-97d2-2cec5496f658

This PR fixes this:

https://github.com/user-attachments/assets/1ab9c0a5-fcd2-4a7b-aed0-6a3b47afe19c


Additionally I also massively improved the rendering of the description component:<br/>
It now no longer constantly checks if the selected mod got changed (pull-based) on the render thread and uses a push-based system instead.