### PR TITLE
Automatically detect parent relationships for generated mods

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -93,6 +93,14 @@ public class FabricMod implements Mod {
 			links.putAll(CustomValueUtil.getStringMap("links", modMenuObject).orElse(new HashMap<>()));
 			allowsUpdateChecks = CustomValueUtil.getBoolean("update_checker", modMenuObject).orElse(true);
 		}
+
+		boolean isGenerated = CustomValueUtil.getBoolean("fabric-loom:generated", metadata).orElse(false);
+
+		/* Automatically set the mod containing a Loom-generated library as its parent */
+		if (isGenerated && parentId.isEmpty() && container.getContainingMod().isPresent()) {
+			ModContainer inside = container.getContainingMod().get();
+			parentId = Optional.of(inside.getMetadata().getId());
+		}
 		this.modMenuData = new ModMenuData(badgeNames, parentId, parentData, id);
 
 		/* Hardcode parents and badges for Fabric API & Fabric Loader */
@@ -117,10 +125,7 @@ public class FabricMod implements Mod {
 		if (this.metadata.getEnvironment() == ModEnvironment.CLIENT) {
 			badges.add(Badge.CLIENT);
 		}
-		if (OptionalUtil.isPresentAndTrue(CustomValueUtil.getBoolean(
-			"fabric-loom:generated",
-			metadata
-		)) || "java".equals(id)) {
+		if (isGenerated || "java".equals(id)) {
 			badges.add(Badge.LIBRARY);
 		}
 		if ("deprecated".equals(CustomValueUtil.getString("fabric-api:module-lifecycle", metadata).orElse(null))) {


### PR DESCRIPTION
Detects which mod regular Java libraries are included in using Loom's `include()` configuration.

This makes the mod list a lot more usable when libraries are shown, as it only shows actual mods.  
Obviously this is not perfect as a library may be included in more than one mod, but I think it's a huge improvement.

![A preview of the feature, showing 13 non-mod libraries that were automatically grouped under Fabric Language Kotlin](https://github.com/user-attachments/assets/459f2a8c-f93e-4844-aef7-305455e3ebc2)
