### PR TITLE
Fix mod list selection highlight rendering going out of bounds

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -1,12 +1,5 @@
 package com.terraformersmc.modmenu.gui.widget;
 
-import com.mojang.blaze3d.buffers.BufferType;
-import com.mojang.blaze3d.buffers.BufferUsage;
-import com.mojang.blaze3d.buffers.GpuBuffer;
-import com.mojang.blaze3d.pipeline.RenderPipeline;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.VertexFormat;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
@@ -18,16 +11,12 @@ import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModSearch;
 import com.terraformersmc.modmenu.util.mod.fabric.FabricIconHandler;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.*;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
-import net.minecraft.client.render.*;
-import net.minecraft.client.util.BufferAllocator;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.ColorHelper;
 import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Matrix4f;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.*;
@@ -230,42 +219,13 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 				int rowWidth = this.getRowWidth();
 				int entryLeft;
 				if (this.isSelectedEntry(index)) {
-					Matrix4f matrix = drawContext.getMatrices().peek().getPositionMatrix();
 					entryLeft = getRowLeft() - 2 + entry.getXOffset();
 					int selectionRight = this.getRowLeft() + rowWidth + 2;
 					float float_2 = this.isFocused() ? 1.0F : 0.5F;
-					final int topColor = ColorHelper.fromFloats(1.0F, float_2, float_2, float_2);
-					final int bottomColor = ColorHelper.fromFloats(1.0F, 0.0F, 0.0F, 0.0F);
-                    RenderPipeline pipeline = RenderPipelines.GUI;
-                    try (BufferAllocator alloc = new BufferAllocator(pipeline.getVertexFormat().getVertexSize() * 4)) {
-                        BufferBuilder bufferBuilder = new BufferBuilder(alloc, pipeline.getVertexFormatMode(), pipeline.getVertexFormat());
-                        bufferBuilder.vertex(matrix, entryLeft, entryTop + entryHeight + 2, 0.0F).color(topColor);
-                        bufferBuilder.vertex(matrix, selectionRight, entryTop + entryHeight + 2, 0.0F).color(topColor);
-                        bufferBuilder.vertex(matrix, selectionRight, entryTop - 2, 0.0F).color(topColor);
-                        bufferBuilder.vertex(matrix, entryLeft, entryTop - 2, 0.0F).color(topColor);
-                        bufferBuilder.vertex(matrix, entryLeft + 1, entryTop + entryHeight + 1, 0.0F).color(bottomColor);
-                        bufferBuilder.vertex(matrix, selectionRight - 1, entryTop + entryHeight + 1, 0.0F).color(bottomColor);
-                        bufferBuilder.vertex(matrix, selectionRight - 1, entryTop - 1, 0.0F).color(bottomColor);
-                        bufferBuilder.vertex(matrix, entryLeft + 1, entryTop - 1, 0.0F).color(bottomColor);
-                        try (BuiltBuffer builtBuffer = bufferBuilder.endNullable()) {
-                            if (builtBuffer == null) {
-                                alloc.close();
-                                return;
-                            }
-                            Framebuffer framebuffer = MinecraftClient.getInstance().getFramebuffer();
-                            RenderSystem.ShapeIndexBuffer autoStorageIndexBuffer = RenderSystem.getSequentialBuffer(pipeline.getVertexFormatMode());
-                            VertexFormat.IndexType indexType = autoStorageIndexBuffer.getIndexType();
-                            GpuBuffer indexBuffer = autoStorageIndexBuffer.getIndexBuffer(builtBuffer.getDrawParameters().indexCount());
-                            GpuBuffer vertexBuffer = RenderSystem.getDevice().createBuffer(() -> "Mod List", BufferType.VERTICES, BufferUsage.DYNAMIC_WRITE, builtBuffer.getBuffer().remaining());
-                            RenderSystem.getDevice().createCommandEncoder().writeToBuffer(vertexBuffer, builtBuffer.getBuffer(), 0);
-                            try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(framebuffer.getColorAttachment(), OptionalInt.empty(), framebuffer.getDepthAttachment(), OptionalDouble.empty())) {
-                                renderPass.setPipeline(pipeline);
-                                renderPass.setVertexBuffer(0, vertexBuffer);
-                                renderPass.setIndexBuffer(indexBuffer, indexType);
-                                renderPass.drawIndexed(0, builtBuffer.getDrawParameters().indexCount());
-                            }
-                        }
-                    }
+                    final int topColor = ColorHelper.fromFloats(1.0F, float_2, float_2, float_2);
+                    final int bottomColor = ColorHelper.fromFloats(1.0F, 0.0F, 0.0F, 0.0F);
+                    drawContext.fill(entryLeft, entryTop - 2, selectionRight, entryTop + entryHeight + 2, topColor);
+                    drawContext.fill(entryLeft + 1, entryTop - 1, selectionRight - 1, entryTop + entryHeight + 1, bottomColor);
 				}
 
 				entryLeft = this.getRowLeft();


### PR DESCRIPTION
Fixes the scissoring not being applied to the selection highlight rendering by using the correct render pipeline which accepts scissor. I also decided to rewrite the code using DrawContext#fill as this is most likely easier to maintain (as Mojang will most likely rewrite the rendering again in the upcoming updates).

Screenshot of the issue:
![image](https://github.com/user-attachments/assets/bd94a6b2-4ed3-4c43-920e-11d9b7ad7451)
