### PR TITLE
[Feature] Mail-To Contacts

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -4,6 +4,7 @@ import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.gui.ModsScreen;
 import com.terraformersmc.modmenu.util.mod.Mod;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -243,7 +244,12 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 							indent = 16;
 
 							for (var line : textRenderer.wrapLines(Text.literal(contributor), wrapWidth - 24)) {
-								children().add(new DescriptionEntry(line, indent));
+                                ContactInformation contact = mod.getContact(contributor);
+                                if (contact != null && contact.get("email").isPresent()) {
+                                    children().add(new MailableContactEntry(line, contact.get("email").get(), indent));
+                                } else {
+									children().add(new DescriptionEntry(line, indent));
+                                }
 								indent = 24;
 							}
 						}
@@ -381,4 +387,38 @@ public class DescriptionListWidget extends EntryListWidget<DescriptionListWidget
 			return super.mouseClicked(mouseX, mouseY, button);
 		}
 	}
+
+    protected class MailableContactEntry extends DescriptionEntry {
+        private final String email;
+
+        public MailableContactEntry(OrderedText text, String email, int indent) {
+            super(text, indent);
+            this.email = email;
+        }
+
+        public MailableContactEntry(OrderedText text, String link) {
+            this(text, link, 0);
+        }
+
+        @Override
+        public void render(DrawContext drawContext, int index, int y, int x, int itemWidth, int itemHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
+            super.render(drawContext, index, y, x, itemWidth, itemHeight, mouseX, mouseY, isSelected, delta);
+            drawContext.drawTextWithShadow(textRenderer, Text.literal(" ").append(Text.literal("✉")), x + indent + textRenderer.getWidth(text) + 1, y, 0xFFAAAAAA);
+        }
+
+        @Override
+        public boolean mouseClicked(double mouseX, double mouseY, int button) {
+            if (isMouseOver(mouseX, mouseY)) {
+                client.setScreen(new ConfirmLinkScreen((open) -> {
+                    if (open) {
+                        Util.getOperatingSystem().open("mailto:" + email);
+                    }
+                    client.setScreen(parent);
+                }, "mailto:" + email, false));
+            }
+
+            return super.mouseClicked(mouseX, mouseY, button);
+        }
+    }
+
 }

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/Mod.java
@@ -7,6 +7,7 @@ import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.mod.fabric.FabricIconHandler;
 import eu.pb4.placeholders.api.ParserContext;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.texture.NativeImageBackedTexture;
 import net.minecraft.text.Text;
@@ -79,6 +80,8 @@ public interface Mod {
 	@NotNull String getPrefixedVersion();
 
 	@NotNull List<String> getAuthors();
+
+    ContactInformation getContact(String author);
 
 	/**
 	 * @return a mapping of contributors to their roles.

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricDummyParentMod.java
@@ -7,6 +7,7 @@ import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 import net.minecraft.client.texture.NativeImageBackedTexture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -94,6 +95,11 @@ public class FabricDummyParentMod implements Mod {
 	}
 
 	@Override
+    public ContactInformation getContact(String author) {
+        return null;
+    }
+
+    @Override
 	public @NotNull Map<String, Collection<String>> getContributors() {
 		return Map.of();
 	}

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/fabric/FabricMod.java
@@ -237,6 +237,21 @@ public class FabricMod implements Mod {
 		return authors;
 	}
 
+    @Override
+    public ContactInformation getContact(String author) {
+        for (Person person : metadata.getAuthors()) {
+            if (person.getName().equals(author)) {
+                return person.getContact();
+            }
+        }
+        for (Person person : metadata.getContributors()) {
+            if (person.getName().equals(author)) {
+                return person.getContact();
+            }
+        }
+        return null;
+    }
+
 	@Override
 	public @NotNull Map<String, Collection<String>> getContributors() {
 		var contributors = new LinkedHashMap<String, Collection<String>>();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -99,7 +99,8 @@
     "Pyrrha",
 	"sakura-ryoko",
 	"gniftygnome",
-	"lowercasebtw"
+	"lowercasebtw",
+	"tnoctua"
   ],
   "description": "Adds a mod menu to view the list of mods you have installed.",
   "mixins": [


### PR DESCRIPTION
This commit adds support for contacting authors/contributors by email if an address provided in accordance to the [fabric.mod.json specification](https://wiki.fabricmc.net/documentation:fabric_mod_json_spec#types).

If an email address is found for a given contributor's contact information, a mail emoticon will be displayed.  Clicking a line with an email emoticon will prompt to open a "mailto:address" link.

Example:

![image](https://github.com/user-attachments/assets/a24cdfdc-cc4c-49c8-b2f5-8f12a41a09a9)
