### PR TITLE
Add missing API annotation, remove confusing log message

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/UpdateChecker.java
@@ -1,5 +1,7 @@
 package com.terraformersmc.modmenu.api;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface UpdateChecker {
 	/**
 	 * Gets called when ModMenu is checking for updates.
@@ -9,5 +11,5 @@ public interface UpdateChecker {
 	 *
 	 * @return The update info
 	 */
-	UpdateInfo checkForUpdates();
+	@Nullable UpdateInfo checkForUpdates();
 }

--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -67,13 +67,11 @@ public class UpdateCheckerUtil {
 						Thread.currentThread().setName("ModMenu/Update Checker/%s".formatted(mod.getName()));
 
 						var update = updateChecker.checkForUpdates();
-
-						if (update == null) {
-							return;
-						}
-
 						mod.setUpdateInfo(update);
-						LOGGER.info("Update available for '{}@{}'", mod.getId(), mod.getVersion());
+
+						if (update != null && update.isUpdateAvailable()) {
+							LOGGER.info("Update available for '{}@{}'", mod.getId(), mod.getVersion());
+						}
 					});
 				}
 			}


### PR DESCRIPTION
Add missing `@Nullable` annotation to the `UpdateChecker` interface.
Remove the update info log when the returned update does not actually have an update.