### PR TITLE
Remove mousescroll override in modsscreen

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -89,19 +89,6 @@ public class ModsScreen extends Screen {
 	}
 
 	@Override
-	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-		if (modList.isMouseOver(mouseX, mouseY)) {
-			return this.modList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
-		}
-
-		if (descriptionListWidget.isMouseOver(mouseX, mouseY)) {
-			return this.descriptionListWidget.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
-		}
-
-		return false;
-	}
-
-	@Override
 	protected void init() {
 		int paneY = ModMenuConfig.CONFIG_MODE.getValue() ? 48 : 48 + 19;
 		this.paneWidth = this.width / 2 - 8;


### PR DESCRIPTION
this override isn't needed as it is implemented in net.minecraft.client.gui.ParentElement and it tries to mousescroll over any selectable child, which implements it and is being hovered over.

i recently added a feature to my mod, which makes you be able to scroll in (most) text input field widgets. however, when i tried to scroll in the text field in the modmenu screen, it didn't work. i decided to dig deeper and found this solution.

the issue is very minor and i don't think it will cause as many problems but i had thought of one: users of my mod might change some options in my mod and then try it out on the mods screen search bar and see that it doesn't work and then probably blame me... i doubt that this will happen often, but i just made this pull request to fix this