### PR TITLE
Prevent show/hide children via mouse from scrolling mod list.

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -158,7 +158,7 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 		return !children.stream().allMatch(child -> child.isHidden() || hideLibraries && child.getBadges().contains(Mod.Badge.LIBRARY));
 	}
 
-	private void filter(String searchTerm, boolean refresh, boolean search) {
+	public void filter(String searchTerm, boolean refresh, boolean reposition) {
 		this.clearEntries();
 		addedMods.clear();
 		Collection<Mod> mods = ModMenu.MODS.values().stream().filter(mod -> {
@@ -207,6 +207,11 @@ public class ModListWidget extends AlwaysSelectedEntryListWidget<ModListEntry> i
 				}
 			}
 		}
+
+        if (!reposition) {
+            // This generally leaves the same mod selected, but no mod highlighted, and the scrolling is unmodified.
+            return;
+        }
 
 		if (parent.getSelectedEntry() != null && !children().isEmpty() || this.getSelectedOrNull() != null && getSelectedOrNull().getMod() != parent.getSelectedEntry().getMod()) {
 			for (ModListEntry entry : children()) {

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/ParentEntry.java
@@ -146,7 +146,7 @@ public class ParentEntry extends ModListEntry {
 			list.getParent().showModChildren.add(id);
 		}
 
-		list.filter(list.getParent().getSearchInput(), false);
+		list.filter(list.getParent().getSearchInput(), false, false);
 	}
 
 	@Override


### PR DESCRIPTION
- Don't scroll when show/hide children (Resolves #911)

This is simple, but there are other ways to resolve it, both in terms of behavior and in code, so I want to give others a chance to comment.
