### PR TITLE
fix: Prevent config button creation for mods without a config implementing ModMenuApi

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -103,8 +103,9 @@ public class ModMenu implements ClientModInitializer {
 			String modId = metadata.getId();
 			try {
 				ModMenuApi api = entrypoint.getEntrypoint();
-				configScreenFactories.put(modId, api.getModConfigScreenFactory());
-				apiImplementations.add(api);
+                var factory = api.getModConfigScreenFactory();
+                if (factory != null) configScreenFactories.put(modId, factory);
+                apiImplementations.add(api);
 				updateCheckers.put(modId, api.getUpdateChecker());
 				providedUpdateCheckers.putAll(api.getProvidedUpdateCheckers());
 				api.attachModpackBadges(modpackMods::add);

--- a/src/main/java/com/terraformersmc/modmenu/api/ModMenuApi.java
+++ b/src/main/java/com/terraformersmc/modmenu/api/ModMenuApi.java
@@ -2,6 +2,7 @@ package com.terraformersmc.modmenu.api;
 
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.gui.ModsScreen;
+import org.jetbrains.annotations.Nullable;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
 
@@ -37,8 +38,8 @@ public interface ModMenuApi {
 	 *
 	 * @return A factory for constructing config screen instances.
 	 */
-	default ConfigScreenFactory<?> getModConfigScreenFactory() {
-		return screen -> null;
+	default @Nullable ConfigScreenFactory<?> getModConfigScreenFactory() {
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Fix config button appearing for mods that implement `ModMenuApi` but do not provide a config screen (clicking it does nothing).

* `ModMenuApi#getModConfigScreenFactory` default now returns null
* Only insert non-null factories into `configScreenFactories`