### PR TITLE
tweak how and when the 'v' prefix is applied by the update checker.

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModrinthUpdateInfo.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModrinthUpdateInfo.java
@@ -15,10 +15,15 @@ public record ModrinthUpdateInfo(String projectId, String versionId, String vers
         return true;
     }
 
-    @Override
-    public @NotNull Component getUpdateMessage() {
-        return Component.translatable("modmenu.updateText", VersionUtil.stripPrefix(this.versionNumber), MODRINTH_TEXT);
-    }
+	@Override
+	public @NotNull Component getUpdateMessage() {
+        String versionNoPrefix = VersionUtil.stripPrefix(this.versionNumber);
+        String key = "modmenu.updateText";
+        if (!Character.isDigit(versionNoPrefix.charAt(0))) {
+            key += ".nonNumerical";
+        }
+        return Component.translatable(key, versionNoPrefix, MODRINTH_TEXT);
+	}
 
     @Override
     public String getDownloadLink() {

--- a/src/main/resources/assets/modmenu/lang/af_za.json
+++ b/src/main/resources/assets/modmenu/lang/af_za.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumeric": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/an-ES.json
+++ b/src/main/resources/assets/modmenu/lang/an-ES.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ar_sa.json
+++ b/src/main/resources/assets/modmenu/lang/ar_sa.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "اشترِ لي كوب قهوة",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ast_es.json
+++ b/src/main/resources/assets/modmenu/lang/ast_es.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/az_az.json
+++ b/src/main/resources/assets/modmenu/lang/az_az.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ba_ru.json
+++ b/src/main/resources/assets/modmenu/lang/ba_ru.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/bak.json
+++ b/src/main/resources/assets/modmenu/lang/bak.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/bar.json
+++ b/src/main/resources/assets/modmenu/lang/bar.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Kauf mir einen Kaffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/be_by.json
+++ b/src/main/resources/assets/modmenu/lang/be_by.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Праверка абнаўленняў у Mod Menu з'яўляецца эксперыментам!)",
   "modmenu.childHasUpdate": "Абнаўленне дзіцячага мода даступна.",
   "modmenu.updateText": "v%s на %s",
+  "modmenu.updateText.nonNumerical": "%s на %s",
   "modmenu.install_version": "Усталяваць версію %s",
   "modmenu.downloadLink": "Спампаваць",
   

--- a/src/main/resources/assets/modmenu/lang/bg_bg.json
+++ b/src/main/resources/assets/modmenu/lang/bg_bg.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/bn-BD.json
+++ b/src/main/resources/assets/modmenu/lang/bn-BD.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/br_fr.json
+++ b/src/main/resources/assets/modmenu/lang/br_fr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/brb.json
+++ b/src/main/resources/assets/modmenu/lang/brb.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/bs_ba.json
+++ b/src/main/resources/assets/modmenu/lang/bs_ba.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ca_es.json
+++ b/src/main/resources/assets/modmenu/lang/ca_es.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/chn.json
+++ b/src/main/resources/assets/modmenu/lang/chn.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ckb-IR.json
+++ b/src/main/resources/assets/modmenu/lang/ckb-IR.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/cs_cz.json
+++ b/src/main/resources/assets/modmenu/lang/cs_cz.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Je dostupná aktualizace:",
   "modmenu.childHasUpdate": "Je dostupná aktualizace podřazeného modu.",
   "modmenu.updateText": "v%s na %s",
+  "modmenu.updateText.nonNumerical": "%s na %s",
   "modmenu.buymeacoffee": "Kupte mi kávu",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/csb-PL.json
+++ b/src/main/resources/assets/modmenu/lang/csb-PL.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/cv-CU.json
+++ b/src/main/resources/assets/modmenu/lang/cv-CU.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/cy_gb.json
+++ b/src/main/resources/assets/modmenu/lang/cy_gb.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/da_dk.json
+++ b/src/main/resources/assets/modmenu/lang/da_dk.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Køb mig en kop kaffe",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/de_at.json
+++ b/src/main/resources/assets/modmenu/lang/de_at.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu Update checker ist experimental!)",
   "modmenu.childHasUpdate": "Eine Abhängigkeit dieser Mod hat ein verfügbares Update.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.install_version": "Installiere version %s",
   "modmenu.downloadLink": "Herunterladen",
   

--- a/src/main/resources/assets/modmenu/lang/de_ch.json
+++ b/src/main/resources/assets/modmenu/lang/de_ch.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu Update checker ist experimental!)",
   "modmenu.childHasUpdate": "Eine Abhängigkeit dieser Mod hat ein verfügbares Update.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.install_version": "Installiere version %s",
   "modmenu.downloadLink": "Herunterladen",
   

--- a/src/main/resources/assets/modmenu/lang/de_de.json
+++ b/src/main/resources/assets/modmenu/lang/de_de.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu Update checker ist experimental!)",
   "modmenu.childHasUpdate": "Eine Abhängigkeit dieser Mod hat ein verfügbares Update.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.install_version": "Installiere version %s",
   "modmenu.downloadLink": "Herunterladen",
   

--- a/src/main/resources/assets/modmenu/lang/dsb-DE.json
+++ b/src/main/resources/assets/modmenu/lang/dsb-DE.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/egl.json
+++ b/src/main/resources/assets/modmenu/lang/egl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Un aggiornamento è disponibile:",
   "modmenu.childHasUpdate": "Un figlio di questa mod ha un aggiornamento disponibile.",
   "modmenu.updateText": "v%s su %s",
+  "modmenu.updateText.nonNumerical": "%s su %s",
   "modmenu.buymeacoffee": "Offrimi un caffè",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/el_gr.json
+++ b/src/main/resources/assets/modmenu/lang/el_gr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Υπάρχει διαθέσιμη ενημέρωση:",
   "modmenu.childHasUpdate": "Ένα παιδί αυτού του mod έχει διαθέσιμη ενημέρωση.",
   "modmenu.updateText": "v%s στο %s",
+  "modmenu.updateText.nonNumerical": "%s στο %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_au.json
+++ b/src/main/resources/assets/modmenu/lang/en_au.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_ca.json
+++ b/src/main/resources/assets/modmenu/lang/en_ca.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_gb.json
+++ b/src/main/resources/assets/modmenu/lang/en_gb.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_nz.json
+++ b/src/main/resources/assets/modmenu/lang/en_nz.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_pt.json
+++ b/src/main/resources/assets/modmenu/lang/en_pt.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_ud.json
+++ b/src/main/resources/assets/modmenu/lang/en_ud.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu update checker is experimental!)",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.install_version": "Install version %s",
   "modmenu.downloadLink": "Download",
 

--- a/src/main/resources/assets/modmenu/lang/enp.json
+++ b/src/main/resources/assets/modmenu/lang/enp.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/enws.json
+++ b/src/main/resources/assets/modmenu/lang/enws.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/eo_uy.json
+++ b/src/main/resources/assets/modmenu/lang/eo_uy.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/es_ar.json
+++ b/src/main/resources/assets/modmenu/lang/es_ar.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(¡El buscador de actualizaciones de Mod Menu es experimental!)",
   "modmenu.childHasUpdate": "Un complemento de este mod tiene una actualización disponible.",
   "modmenu.updateText": "v%s en %s",
+  "modmenu.updateText.nonNumerical": "%s en %s",
   "modmenu.install_version": "Instalar versión %s",
   "modmenu.downloadLink": "Descargar",
 

--- a/src/main/resources/assets/modmenu/lang/es_cl.json
+++ b/src/main/resources/assets/modmenu/lang/es_cl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/es_ec.json
+++ b/src/main/resources/assets/modmenu/lang/es_ec.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/es_es.json
+++ b/src/main/resources/assets/modmenu/lang/es_es.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(La característica de comprobación de actualizaciones es experimental.)",
   "modmenu.childHasUpdate": "Actualización disponible para mod secundario.",
   "modmenu.updateText": "v%s en %s",
+  "modmenu.updateText.nonNumerical": "%s en %s",
   "modmenu.install_version": "Instalar versión %s",
   "modmenu.downloadLink": "Descargar",
 
@@ -95,7 +96,7 @@
   "modmenu.credits.role.playtester": "Testers",
   "modmenu.credits.role.illustrator": "Ilustradores",
   "modmenu.credits.role.owner": "Propietarios",
-	
+
   "modmenu.modsFolder": "Abrir carpeta de mods",
   "modmenu.configsFolder": "Abrir carpeta de opciones",
 

--- a/src/main/resources/assets/modmenu/lang/es_mx.json
+++ b/src/main/resources/assets/modmenu/lang/es_mx.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/es_uy.json
+++ b/src/main/resources/assets/modmenu/lang/es_uy.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/es_ve.json
+++ b/src/main/resources/assets/modmenu/lang/es_ve.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/esan.json
+++ b/src/main/resources/assets/modmenu/lang/esan.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Comprame un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/et_ee.json
+++ b/src/main/resources/assets/modmenu/lang/et_ee.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Uuendus on saadaval:",
   "modmenu.childHasUpdate": "Selle modi alammodil on saadaolev uuendus.",
   "modmenu.updateText": "v%s platvormil %s",
+  "modmenu.updateText.nonNumerical": "%s platvormil %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/eu_es.json
+++ b/src/main/resources/assets/modmenu/lang/eu_es.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fa_ir.json
+++ b/src/main/resources/assets/modmenu/lang/fa_ir.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fi_fi.json
+++ b/src/main/resources/assets/modmenu/lang/fi_fi.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fil_ph.json
+++ b/src/main/resources/assets/modmenu/lang/fil_ph.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fo_fo.json
+++ b/src/main/resources/assets/modmenu/lang/fo_fo.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fr_ca.json
+++ b/src/main/resources/assets/modmenu/lang/fr_ca.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fr_fr.json
+++ b/src/main/resources/assets/modmenu/lang/fr_fr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Une mise à jour est disponible :",
   "modmenu.childHasUpdate": "Un mod complémentaire a une mise à jour disponible.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Offrez-moi un café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fra_de.json
+++ b/src/main/resources/assets/modmenu/lang/fra_de.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fur_it.json
+++ b/src/main/resources/assets/modmenu/lang/fur_it.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/fy_nl.json
+++ b/src/main/resources/assets/modmenu/lang/fy_nl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ga_ie.json
+++ b/src/main/resources/assets/modmenu/lang/ga_ie.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/gd_gb.json
+++ b/src/main/resources/assets/modmenu/lang/gd_gb.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/gl_es.json
+++ b/src/main/resources/assets/modmenu/lang/gl_es.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/got_de.json
+++ b/src/main/resources/assets/modmenu/lang/got_de.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/gv_im.json
+++ b/src/main/resources/assets/modmenu/lang/gv_im.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/haw_us.json
+++ b/src/main/resources/assets/modmenu/lang/haw_us.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/he_il.json
+++ b/src/main/resources/assets/modmenu/lang/he_il.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hes.json
+++ b/src/main/resources/assets/modmenu/lang/hes.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Kauf mir einen Kaffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hi_in.json
+++ b/src/main/resources/assets/modmenu/lang/hi_in.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hr_hr.json
+++ b/src/main/resources/assets/modmenu/lang/hr_hr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hsb-DE.json
+++ b/src/main/resources/assets/modmenu/lang/hsb-DE.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hu_hu.json
+++ b/src/main/resources/assets/modmenu/lang/hu_hu.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Frissítés érhető el:",
   "modmenu.childHasUpdate": "Ennek a modnak egyik almodulja frissítést kapott.",
   "modmenu.updateText": "v%s (%s)",
+  "modmenu.updateText.nonNumerical": "%s (%s)",
   "modmenu.buymeacoffee": "Vegyél nekem kávét",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/hy_am.json
+++ b/src/main/resources/assets/modmenu/lang/hy_am.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Ինծ Սուրծ մը գնէ",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/id_id.json
+++ b/src/main/resources/assets/modmenu/lang/id_id.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ig_ng.json
+++ b/src/main/resources/assets/modmenu/lang/ig_ng.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/io_en.json
+++ b/src/main/resources/assets/modmenu/lang/io_en.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/is_is.json
+++ b/src/main/resources/assets/modmenu/lang/is_is.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/isv.json
+++ b/src/main/resources/assets/modmenu/lang/isv.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/it_it.json
+++ b/src/main/resources/assets/modmenu/lang/it_it.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Un aggiornamento è disponibile:",
   "modmenu.childHasUpdate": "Un figlio di questa mod ha un aggiornamento disponibile.",
   "modmenu.updateText": "v%s su %s",
+  "modmenu.updateText.nonNumerical": "%s su %s",
   "modmenu.buymeacoffee": "Offrimi un caffè",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ja_jp.json
+++ b/src/main/resources/assets/modmenu/lang/ja_jp.json
@@ -62,6 +62,7 @@
   "modmenu.hasUpdate": "新しいバージョンが利用可能：",
   "modmenu.childHasUpdate": "子Modのアップデートがあります。",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "コーヒー代を寄付する",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/jbo_en.json
+++ b/src/main/resources/assets/modmenu/lang/jbo_en.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ka_ge.json
+++ b/src/main/resources/assets/modmenu/lang/ka_ge.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/kab-KAB.json
+++ b/src/main/resources/assets/modmenu/lang/kab-KAB.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/kk_kz.json
+++ b/src/main/resources/assets/modmenu/lang/kk_kz.json
@@ -63,6 +63,7 @@
   "modmenu.hasUpdate": "Жаңарту қолжетімді:",
   "modmenu.childHasUpdate": "Осы модқа тәуелді модқа жаңарту қолжетімді",
   "modmenu.updateText": "%s нұсқасы, %s",
+  "modmenu.updateText.nonNumerical": "%s нұсқасы, %s",
   "modmenu.install_version": "%s нұсқасын орнату",
   "modmenu.downloadLink": "Жүктеу",
 

--- a/src/main/resources/assets/modmenu/lang/kn_in.json
+++ b/src/main/resources/assets/modmenu/lang/kn_in.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ko_kr.json
+++ b/src/main/resources/assets/modmenu/lang/ko_kr.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu의 업데이트 확인기능은 실험적 기능입니다!)",
   "modmenu.childHasUpdate": "이 모드의 하위 항목에 사용 가능한 업데이트가 있습니다.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.install_version": "Install version %s",
   "modmenu.downloadLink": "다운로드",
 

--- a/src/main/resources/assets/modmenu/lang/ksh.json
+++ b/src/main/resources/assets/modmenu/lang/ksh.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Kauf mir einen Kaffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/kw_gb.json
+++ b/src/main/resources/assets/modmenu/lang/kw_gb.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/la_la.json
+++ b/src/main/resources/assets/modmenu/lang/la_la.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lb_lu.json
+++ b/src/main/resources/assets/modmenu/lang/lb_lu.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/li_li.json
+++ b/src/main/resources/assets/modmenu/lang/li_li.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lmo.json
+++ b/src/main/resources/assets/modmenu/lang/lmo.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Un aggiornamento è disponibile:",
   "modmenu.childHasUpdate": "Un figlio di questa mod ha un aggiornamento disponibile.",
   "modmenu.updateText": "v%s su %s",
+  "modmenu.updateText.nonNumerical": "%s su %s",
   "modmenu.buymeacoffee": "Offrimi un caffè",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lol_us.json
+++ b/src/main/resources/assets/modmenu/lang/lol_us.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lt_lt.json
+++ b/src/main/resources/assets/modmenu/lang/lt_lt.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lv_lv.json
+++ b/src/main/resources/assets/modmenu/lang/lv_lv.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Nopērc Man Kafiju",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/lzh.json
+++ b/src/main/resources/assets/modmenu/lang/lzh.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "有更新可用：",
   "modmenu.childHasUpdate": "此模組的一個子模組有更新。",
   "modmenu.updateText": "%2$s 中的 v%1$s",
+  "modmenu.updateText.nonNumerical": "%2$s 中的 %1$s",
   "modmenu.buymeacoffee": "予吾一茶",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/me-ME.json
+++ b/src/main/resources/assets/modmenu/lang/me-ME.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/mi_NZ.json
+++ b/src/main/resources/assets/modmenu/lang/mi_NZ.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/mk_mk.json
+++ b/src/main/resources/assets/modmenu/lang/mk_mk.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/mn_mn.json
+++ b/src/main/resources/assets/modmenu/lang/mn_mn.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/moe.json
+++ b/src/main/resources/assets/modmenu/lang/moe.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/moh-CA.json
+++ b/src/main/resources/assets/modmenu/lang/moh-CA.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ms_my.json
+++ b/src/main/resources/assets/modmenu/lang/ms_my.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Terdapat kemas kini baharu:",
   "modmenu.childHasUpdate": "Terdapat kemas kini untuk anak kepada mod ini.",
   "modmenu.updateText": "v%s di %s",
+  "modmenu.updateText.nonNumerical": "%s di %s",
   "modmenu.buymeacoffee": "Belikan Saya Kopi",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/mt_mt.json
+++ b/src/main/resources/assets/modmenu/lang/mt_mt.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/nah.json
+++ b/src/main/resources/assets/modmenu/lang/nah.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/nds_de.json
+++ b/src/main/resources/assets/modmenu/lang/nds_de.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ne-NP.json
+++ b/src/main/resources/assets/modmenu/lang/ne-NP.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/nl_be.json
+++ b/src/main/resources/assets/modmenu/lang/nl_be.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/nl_nl.json
+++ b/src/main/resources/assets/modmenu/lang/nl_nl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/nn_no.json
+++ b/src/main/resources/assets/modmenu/lang/nn_no.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/no_no.json
+++ b/src/main/resources/assets/modmenu/lang/no_no.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod-menyens oppdaterings-sjekker er eksperimentell!)",
   "modmenu.childHasUpdate": "Et barn av denne modden har en oppdatering tilgjengelig.",
   "modmenu.updateText": "v%s på %s",
+  "modmenu.updateText.nonNumerical": "%s på %s",
   
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",

--- a/src/main/resources/assets/modmenu/lang/nuk.json
+++ b/src/main/resources/assets/modmenu/lang/nuk.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/oc_fr.json
+++ b/src/main/resources/assets/modmenu/lang/oc_fr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/oj-CA.json
+++ b/src/main/resources/assets/modmenu/lang/oj-CA.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ovd.json
+++ b/src/main/resources/assets/modmenu/lang/ovd.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/pl_pl.json
+++ b/src/main/resources/assets/modmenu/lang/pl_pl.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Funkcja sprawdzania aktualizacji jest eksperymentalna!)",
   "modmenu.childHasUpdate": "Mod potomny tego modu ma dostępną aktualizację.",
   "modmenu.updateText": "v%s na %s",
+  "modmenu.updateText.nonNumerical": "%s na %s",
   "modmenu.install_version": "Zainstaluj wersję %s",
   "modmenu.downloadLink": "Pobierz",
   

--- a/src/main/resources/assets/modmenu/lang/pt_br.json
+++ b/src/main/resources/assets/modmenu/lang/pt_br.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/pt_pt.json
+++ b/src/main/resources/assets/modmenu/lang/pt_pt.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Compra-me um café",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/qya_aa.json
+++ b/src/main/resources/assets/modmenu/lang/qya_aa.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ro_ro.json
+++ b/src/main/resources/assets/modmenu/lang/ro_ro.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/rpr.json
+++ b/src/main/resources/assets/modmenu/lang/rpr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Доступно обновление:",
   "modmenu.childHasUpdate": "Доступно обновление для дочернего мода.",
   "modmenu.updateText": "v%s на %s",
+  "modmenu.updateText.nonNumerical": "%s на %s",
   "modmenu.buymeacoffee": "Извольте Оплатить Мой Кофе",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ru_ru.json
+++ b/src/main/resources/assets/modmenu/lang/ru_ru.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(проверка обновлений ModMenu экспериментальна)",
   "modmenu.childHasUpdate": "Доступно обновление для дочернего мода.",
   "modmenu.updateText": "v%s на %s",
+  "modmenu.updateText.nonNumerical": "%s на %s",
   "modmenu.install_version": "Установить версию %s",
   "modmenu.downloadLink": "Загрузить",
   

--- a/src/main/resources/assets/modmenu/lang/sah-SAH.json
+++ b/src/main/resources/assets/modmenu/lang/sah-SAH.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/scn.json
+++ b/src/main/resources/assets/modmenu/lang/scn.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Un aggiornamento è disponibile:",
   "modmenu.childHasUpdate": "Un figlio di questa mod ha un aggiornamento disponibile.",
   "modmenu.updateText": "v%s su %s",
+  "modmenu.updateText.nonNumerical": "%s su %s",
   "modmenu.buymeacoffee": "Offrimi un caffè",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/se_no.json
+++ b/src/main/resources/assets/modmenu/lang/se_no.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sjd.json
+++ b/src/main/resources/assets/modmenu/lang/sjd.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Доступно обновление:",
   "modmenu.childHasUpdate": "Доступно обновление для дочернего мода.",
   "modmenu.updateText": "v%s на %s",
+  "modmenu.updateText.nonNumerical": "%s на %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sk_sk.json
+++ b/src/main/resources/assets/modmenu/lang/sk_sk.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Je k dispozícii aktualizácia:",
   "modmenu.childHasUpdate": "Dedič tohto modu má k dispozícii aktualizáciu.",
   "modmenu.updateText": "v%s na %s",
+  "modmenu.updateText.nonNumerical": "%s na %s",
   "modmenu.buymeacoffee": "Kúp mi kávu",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sl_si.json
+++ b/src/main/resources/assets/modmenu/lang/sl_si.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/so_so.json
+++ b/src/main/resources/assets/modmenu/lang/so_so.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sq_al.json
+++ b/src/main/resources/assets/modmenu/lang/sq_al.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sr-Cyrl-ME.json
+++ b/src/main/resources/assets/modmenu/lang/sr-Cyrl-ME.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sr_sp.json
+++ b/src/main/resources/assets/modmenu/lang/sr_sp.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sv_se.json
+++ b/src/main/resources/assets/modmenu/lang/sv_se.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/swg.json
+++ b/src/main/resources/assets/modmenu/lang/swg.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Kauf mir einen Kaffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/sxu.json
+++ b/src/main/resources/assets/modmenu/lang/sxu.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Kauf mir einen Kaffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/szl.json
+++ b/src/main/resources/assets/modmenu/lang/szl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Aktualizacja jest dostępna:",
   "modmenu.childHasUpdate": "Dziecko tego modu ma dostępną aktualizację.",
   "modmenu.updateText": "v%s na %s",
+  "modmenu.updateText.nonNumerical": "%s na %s",
   "modmenu.buymeacoffee": "Kup Autorowi Kawę",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/ta_in.json
+++ b/src/main/resources/assets/modmenu/lang/ta_in.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/th_th.json
+++ b/src/main/resources/assets/modmenu/lang/th_th.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "ช่วยออกค่ากาแฟได้ที่นี่",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/tl_ph.json
+++ b/src/main/resources/assets/modmenu/lang/tl_ph.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/tlh_aa.json
+++ b/src/main/resources/assets/modmenu/lang/tlh_aa.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/tok.json
+++ b/src/main/resources/assets/modmenu/lang/tok.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "o esun e telo wawa tawa mi",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/tr_tr.json
+++ b/src/main/resources/assets/modmenu/lang/tr_tr.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "Bir güncelleme mevcut:",
   "modmenu.childHasUpdate": "Bu modun alt biriminin bir güncellemesi var.",
   "modmenu.updateText": "v%s (%s üzerinde)",
+  "modmenu.updateText.nonNumerical": "%s (%s üzerinde)",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/tt_ru.json
+++ b/src/main/resources/assets/modmenu/lang/tt_ru.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Mod Menu яңарту тикшерүчесе — эксперименталь функция!)",
   "modmenu.childHasUpdate": "Бу модның бала өчен яңарту бар.",
   "modmenu.updateText": "%2$s сайтында %1$s версиясе",
+  "modmenu.updateText.nonNumerical": "%2$s сайтында %1$s версиясе",
   "modmenu.install_version": "%s версиясен утырту",
   "modmenu.downloadLink": "Йөкләнү",
   

--- a/src/main/resources/assets/modmenu/lang/tzl_tzl.json
+++ b/src/main/resources/assets/modmenu/lang/tzl_tzl.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/uk_ua.json
+++ b/src/main/resources/assets/modmenu/lang/uk_ua.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Перевірка оновлень є експериментальною!)",
   "modmenu.childHasUpdate": "Дочірній мод цього мода має доступне оновлення",
   "modmenu.updateText": "v%s на %s",
+  "modmenu.updateText.nonNumerical": "%s на %s",
   "modmenu.install_version": "Установити версію %s",
   "modmenu.downloadLink": "Завантажити",
 

--- a/src/main/resources/assets/modmenu/lang/ur-PK.json
+++ b/src/main/resources/assets/modmenu/lang/ur-PK.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/uz-UZ.json
+++ b/src/main/resources/assets/modmenu/lang/uz-UZ.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/val_es.json
+++ b/src/main/resources/assets/modmenu/lang/val_es.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/vec_it.json
+++ b/src/main/resources/assets/modmenu/lang/vec_it.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/vi_vn.json
+++ b/src/main/resources/assets/modmenu/lang/vi_vn.json
@@ -63,6 +63,7 @@
   "modmenu.experimental": "(Trình kiểm tra cập nhật của Mod Menu hiện đang trong giai đoạn thử nghiệm!)",
   "modmenu.childHasUpdate": "Mod con của mod hiện tại có bản cập nhật mới.",
   "modmenu.updateText": "v%s trên %s",
+  "modmenu.updateText.nonNumerical": "%s trên %s",
   "modmenu.install_version": "Cài đặt bản %s",
   "modmenu.downloadLink": "Tải xuống",
   

--- a/src/main/resources/assets/modmenu/lang/yi_de.json
+++ b/src/main/resources/assets/modmenu/lang/yi_de.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/yo_ng.json
+++ b/src/main/resources/assets/modmenu/lang/yo_ng.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/zh_cn.json
+++ b/src/main/resources/assets/modmenu/lang/zh_cn.json
@@ -56,6 +56,7 @@
   "modmenu.experimental": "(更新检测器处于实验阶段！)",
   "modmenu.childHasUpdate": "此模组的一个子模组有更新。",
   "modmenu.updateText": "%2$s中的v%1$s",
+  "modmenu.updateText.nonNumerical": "%2$s中的%1$s",
   "modmenu.downloadLink": "下载",
   "modmenu.buymeacoffee": "给我买一杯咖啡",
   "modmenu.coindrop": "Coindrop",

--- a/src/main/resources/assets/modmenu/lang/zh_hk.json
+++ b/src/main/resources/assets/modmenu/lang/zh_hk.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "An update is available:",
   "modmenu.childHasUpdate": "A child of this mod has an update available.",
   "modmenu.updateText": "v%s on %s",
+  "modmenu.updateText.nonNumerical": "%s on %s",
   "modmenu.buymeacoffee": "Buy Me a Coffee",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",

--- a/src/main/resources/assets/modmenu/lang/zh_tw.json
+++ b/src/main/resources/assets/modmenu/lang/zh_tw.json
@@ -54,6 +54,7 @@
   "modmenu.hasUpdate": "有更新可用：",
   "modmenu.childHasUpdate": "此模組的一個子模組有更新。",
   "modmenu.updateText": "%2$s 中的 v%1$s",
+  "modmenu.updateText.nonNumerical": "%2$s 中的 %1$s",
   "modmenu.buymeacoffee": "請我喝杯咖啡",
   "modmenu.coindrop": "Coindrop",
   "modmenu.crowdin": "Crowdin",


### PR DESCRIPTION
Some mods start their version strings with something other than a number or a 'v' prefix such as Sodium and Simple Voice Chat (examples below) which can make the 'v' prefix applied by the update checker look a bit messy.

This simply checks if the first character of a version string isn't a number (using `!Character.isDigit`) and appends `.nonNumeric` to the translation key which is a duplicate of the previous key without the 'v' prefix. Versions starting with a number aren't changed.

Sodium before:
<img width="1175" height="186" alt="Screenshot_20251224_165913" src="https://github.com/user-attachments/assets/a2e8dde5-4411-4b82-bcc4-5f13fe1b7673" />

Sodium after:
<img width="1153" height="171" alt="Screenshot_20251224_165821" src="https://github.com/user-attachments/assets/0021cefe-657e-4774-b6b0-09689689a68b" />

Simple Voice Chat before:
<img width="1175" height="186" alt="Screenshot_20251224_165919" src="https://github.com/user-attachments/assets/28feea40-0061-449f-8283-6547c9eb5a15" />

Simple Voice Chat after:
<img width="1164" height="190" alt="Screenshot_20251224_165831" src="https://github.com/user-attachments/assets/119e47be-b0e1-4e4a-bf83-cdb57d71bd0c" />

Fabric Api before and after:
<img width="1175" height="186" alt="Screenshot_20251224_170728" src="https://github.com/user-attachments/assets/14f72b78-b624-4ae8-9d5a-6632fefadbd0" />