### PR TITLE
Add timeouts for HTTP requests

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/HttpUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/HttpUtil.java
@@ -9,11 +9,14 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 
 public class HttpUtil {
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
     private static final String USER_AGENT = buildUserAgent();
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
             .executor(Util.nonCriticalIoPool())
+            .connectTimeout(TIMEOUT)
             .build();
 
     private HttpUtil() {
@@ -24,6 +27,7 @@ public class HttpUtil {
             HttpResponse.BodyHandler<T> handler
     ) throws IOException, InterruptedException {
         builder.setHeader("User-Agent", USER_AGENT);
+        builder.timeout(TIMEOUT);
         return HTTP_CLIENT.send(builder.build(), handler);
     }
 


### PR DESCRIPTION
There are currently no timeouts when performing a HTTP request.

This causes various problems like stuck threads or even worse: Blocks the game from loading (as described in #953)

The change should maybe also be considered for backporting to older versions.