### PR TITLE
fix config mode being worse than useless

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -163,7 +163,7 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
         addedMods.clear();
         Collection<Mod> mods = ModMenu.MODS.values().stream().filter(mod -> {
             if (ModMenuConfig.CONFIG_MODE.getValue()) {
-                return !parent.getModHasConfigScreen(mod.getId());
+                return parent.getModHasConfigScreen(mod.getId());
             } else {
                 return !mod.isHidden();
             }


### PR DESCRIPTION
showed only mods without config screens, instead of with.

double negation typo introduced in 11.0.3, so affects 1.21.1 and above.