### PR TITLE
Fix description wrapping after filtering

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -207,6 +207,12 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
             }
         }
 
+        // Entries are assigned their width as they are added. The first entries can be
+        // measured before the final content height makes scrollbar presence stable,
+        // which leaves wrapped descriptions using a stale row width until scrolling
+        // happens to reposition the list.
+        this.repositionEntriesAfterContentChange();
+
         if (!reposition) {
             // This generally leaves the same mod selected, but no mod highlighted, and the scrolling is unmodified.
             return;
@@ -226,6 +232,19 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
 
         if (scrollAmount() > Math.max(0, this.contentHeight() - (this.getBottom() - this.getY() - 4))) {
             setScrollAmount(Math.max(0, this.contentHeight() - (this.getBottom() - this.getY() - 4)));
+        }
+    }
+
+    private void repositionEntriesAfterContentChange() {
+        int rowLeft = this.getRowLeft();
+        int rowWidth = this.getRowWidth();
+        int nextY = this.getY() + 2 - (int) this.scrollAmount();
+
+        for (ModListEntry entry : children()) {
+            entry.setX(rowLeft);
+            entry.setWidth(rowWidth);
+            entry.setY(nextY);
+            nextY += entry.getHeight();
         }
     }
 


### PR DESCRIPTION
﻿Fixes #991.

Entries receive their x/width/y values as they are added to the list. During filtering, early entries can be measured before the final content height makes scrollbar presence stable, so wrapped descriptions may use a stale row width until scrolling triggers the list to reposition its entries.

This repositions the rebuilt entries once after filtering has finished, preserving the current scroll amount while making row widths consistent before the first render.

Tested with:
- `./gradlew.bat build`
