### PR TITLE
Handle update checker failures gracefully

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -79,6 +79,7 @@ public class UpdateCheckerUtil {
         }
 
         if (modrinthApiV2Deprecated) {
+            executor.shutdown();
             return;
         }
 
@@ -94,12 +95,14 @@ public class UpdateCheckerUtil {
             currentVersions = currentVersionsFuture.get();
             updatedVersions = updatedVersionsFuture.get();
         } catch (ExecutionException e) {
-            throw new RuntimeException(e);
+            LOGGER.error("Error checking for updates: ", e.getCause() != null ? e.getCause() : e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            LOGGER.error("Error checking for updates: ", e);
         }
 
         if (currentVersions == null || updatedVersions == null) {
+            executor.shutdown();
             return;
         }
 
@@ -201,7 +204,10 @@ public class UpdateCheckerUtil {
 
                 return results;
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Error checking for versions: ", e);
+        } catch (IOException | RuntimeException e) {
             LOGGER.error("Error checking for versions: ", e);
         }
 
@@ -304,7 +310,10 @@ public class UpdateCheckerUtil {
 
                 return results;
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Error checking for updates: ", e);
+        } catch (IOException | RuntimeException e) {
             LOGGER.error("Error checking for updates: ", e);
         }
 


### PR DESCRIPTION
﻿## Summary
- log update-check future failures instead of rethrowing them as runtime exceptions
- treat malformed Modrinth update responses as a failed update check instead of a client crash
- restore the interrupt flag when update-check requests are interrupted

## Root Cause
#1011's log shows a timeout followed by a malformed/truncated Modrinth JSON response. The parser exception escaped through `Future.get()`, and `checkForUpdates0` rethrew the `ExecutionException` as a `RuntimeException`, which crashed Minecraft.

## Validation
- `./gradlew.bat build`

Fixes #1011
