### PR TITLE
Fix selection and scroll amount not restoring

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -264,10 +264,6 @@ public class ModsScreen extends Screen {
         this.addRenderableWidget(modsFolderButton);
         this.addRenderableWidget(doneButton);
 
-        // Ensure a valid entry is selected
-        this.updateSelectedEntry(this.modList.getEntry(0));
-        this.modList.select(this.selected);
-
         this.init = true;
         this.keepFilterOptionsShown = true;
     }

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -137,7 +137,7 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
     }
 
     public void finalizeInit() {
-        reloadFilters();
+        filter(parent.getSearchInput(), true, true);
         if (restoreScrollY != null) {
             setScrollAmount(restoreScrollY);
             restoreScrollY = null;


### PR DESCRIPTION
Fixes #1020 

The commit https://github.com/TerraformersMC/ModMenu/commit/5e16dfa092f68af5879c567fcc0ec2713fcf557d broke the fix on #837 since selecting an entry also scrolls to that entry on `AbstractSelectionList` since Minecraft 1.21.9

Passing `true` to `reposition` when reloading filters on `ModListWidget#finalizeInit` already ensures that either the last selected or the first entry will be selected, and `finalizeInit` will restore the scroll amount anyway.