### PR TITLE
Add support for showing configurable libraries

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/ModMenu.java
+++ b/src/main/java/com/terraformersmc/modmenu/ModMenu.java
@@ -205,7 +205,7 @@ public class ModMenu implements ClientModInitializer {
                 continue;
             }
 
-            if (!ModMenuConfig.SHOW_LIBRARIES.getValue() && mod.getBadges().contains(Mod.Badge.LIBRARY)) {
+            if (ModMenuConfig.SHOW_LIBRARIES.getValue().hideMod(mod, getConfigScreenFactory(mod.getId()) != null)) {
                 continue;
             }
 

--- a/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
+++ b/src/main/java/com/terraformersmc/modmenu/config/ModMenuConfig.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.function.Predicate;
 
 import net.minecraft.client.OptionInstance;
 
@@ -27,7 +28,7 @@ public class ModMenuConfig {
     public static final BooleanConfigOption COUNT_HIDDEN_MODS = new BooleanConfigOption("count_hidden_mods", true);
     public static final EnumConfigOption<ModCountLocation> MOD_COUNT_LOCATION = new EnumConfigOption<>("mod_count_location", ModCountLocation.TITLE_SCREEN);
     public static final BooleanConfigOption HIDE_MOD_LINKS = new BooleanConfigOption("hide_mod_links", false);
-    public static final BooleanConfigOption SHOW_LIBRARIES = new BooleanConfigOption("show_libraries", false);
+    public static final EnumConfigOption<LibraryVisibility> SHOW_LIBRARIES = new EnumConfigOption<>("show_libraries", LibraryVisibility.WITH_CONFIG);
     public static final BooleanConfigOption HIDE_MOD_LICENSE = new BooleanConfigOption("hide_mod_license", false);
     public static final BooleanConfigOption HIDE_BADGES = new BooleanConfigOption("hide_badges", false);
     public static final BooleanConfigOption HIDE_MOD_CREDITS = new BooleanConfigOption("hide_mod_credits", false);
@@ -87,6 +88,24 @@ public class ModMenuConfig {
 
         public Comparator<Mod> getComparator() {
             return comparator;
+        }
+    }
+
+    public enum LibraryVisibility {
+        FALSE,
+        WITH_CONFIG,
+        TRUE;
+
+        public boolean hideMod(Mod mod, boolean hasConfig) {
+            return switch (this) {
+                case TRUE -> false;
+                case FALSE -> mod.getBadges().contains(Mod.Badge.LIBRARY);
+                case WITH_CONFIG -> mod.getBadges().contains(Mod.Badge.LIBRARY) && !hasConfig;
+            };
+        }
+
+        public boolean isTrue() {
+            return this == TRUE;
         }
     }
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -18,10 +18,7 @@ import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModOrigin;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.EditBox;
-import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.components.*;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.client.gui.screens.ConfirmLinkScreen;
 import net.minecraft.client.gui.screens.ConfirmScreen;
@@ -162,7 +159,10 @@ public class ModsScreen extends Screen {
 
         // Show libraries button
         this.librariesButton = Button.builder(librariesText, button -> {
-            ModMenuConfig.SHOW_LIBRARIES.toggleValue();
+            var values = ModMenuConfig.LibraryVisibility.values();
+            var value = ModMenuConfig.SHOW_LIBRARIES.getValue().ordinal();
+
+            ModMenuConfig.SHOW_LIBRARIES.setValue(values[(values.length + value + (minecraft.hasShiftDown() ? -1 : 1) ) % values.length]);
             ModMenuConfigManager.save();
             modList.reloadFilters();
             button.setMessage(ModMenuConfig.SHOW_LIBRARIES.getButtonText());
@@ -311,8 +311,7 @@ public class ModsScreen extends Screen {
             Component fullModCount = this.computeModCountText(true, false);
             if (!ModMenuConfig.CONFIG_MODE.getValue() && this.updateFiltersX(false)) {
                 if (this.filterOptionsShown) {
-                    if (!ModMenuConfig.SHOW_LIBRARIES.getValue() ||
-                            font.width(fullModCount) <= this.filtersX - 5) {
+                    if (font.width(fullModCount) <= this.filtersX - 5) {
                         drawContext.text(
                                 font,
                                 fullModCount.getVisualOrderText(),
@@ -340,8 +339,7 @@ public class ModsScreen extends Screen {
                         );
                     }
                 } else {
-                    if (!ModMenuConfig.SHOW_LIBRARIES.getValue() ||
-                            font.width(fullModCount) <= modList.getWidth() - 5) {
+                    if (font.width(fullModCount) <= modList.getWidth() - 5) {
                         drawContext.text(font,
                                 fullModCount.getVisualOrderText(),
                                 this.searchBoxX,
@@ -458,23 +456,29 @@ public class ModsScreen extends Screen {
                 .filter(mod -> !mod.isHidden() && !mod.getBadges().contains(Mod.Badge.LIBRARY))
                 .map(Mod::getId)
                 .collect(Collectors.toSet()), onInit);
-        if (includeLibs && ModMenuConfig.SHOW_LIBRARIES.getValue() && !onInit) {
+        if (includeLibs && !onInit) {
+            var visibility = ModMenuConfig.SHOW_LIBRARIES.getValue();
+
             int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values()
                     .stream()
-                    .filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY))
+                    .filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY) && !visibility.hideMod(mod, getModHasConfigScreen(mod.getId())))
                     .map(Mod::getId)
                     .collect(Collectors.toSet()), false);
-            return TranslationUtil.translateNumeric("modmenu.showingModsLibraries", rootMods, rootLibs);
-        } else {
-            return TranslationUtil.translateNumeric("modmenu.showingMods", rootMods);
+
+            if (rootLibs.length == 1 && rootLibs[0] != 0 || rootLibs.length == 2 && rootLibs[1] != 0) {
+                return TranslationUtil.translateNumeric("modmenu.showingModsLibraries", rootMods, rootLibs);
+            }
         }
+
+        return TranslationUtil.translateNumeric("modmenu.showingMods", rootMods);
     }
 
     private Component computeLibraryCountText(boolean onInit) {
-        if (ModMenuConfig.SHOW_LIBRARIES.getValue() && !onInit) {
+        var visibility = ModMenuConfig.SHOW_LIBRARIES.getValue();
+        if (!onInit) {
             int[] rootLibs = formatModCount(ModMenu.ROOT_MODS.values()
                     .stream()
-                    .filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY))
+                    .filter(mod -> !mod.isHidden() && mod.getBadges().contains(Mod.Badge.LIBRARY) && !visibility.hideMod(mod, this.getModHasConfigScreen(mod.getId())))
                     .map(Mod::getId)
                     .collect(Collectors.toSet()), false);
             return TranslationUtil.translateNumeric("modmenu.showingLibraries", rootLibs);

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/ModListWidget.java
@@ -154,8 +154,8 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
 
     private boolean hasVisibleChildMods(Mod parent) {
         List<Mod> children = ModMenu.PARENT_MAP.get(parent);
-        boolean hideLibraries = !ModMenuConfig.SHOW_LIBRARIES.getValue();
-        return !children.stream().allMatch(child -> child.isHidden() || hideLibraries && child.getBadges().contains(Mod.Badge.LIBRARY));
+        ModMenuConfig.LibraryVisibility libraryVisibility = ModMenuConfig.SHOW_LIBRARIES.getValue();
+        return !children.stream().allMatch(child -> child.isHidden() || libraryVisibility.hideMod(child, this.parent.getModHasConfigScreen(child.getId())));
     }
 
     public void filter(String searchTerm, boolean refresh, boolean reposition) {
@@ -183,7 +183,7 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
             String modId = mod.getId();
 
             //Hide parent lib mods when the config is set to hide
-            if (mod.getBadges().contains(Mod.Badge.LIBRARY) && !ModMenuConfig.SHOW_LIBRARIES.getValue()) {
+            if (ModMenuConfig.SHOW_LIBRARIES.getValue().hideMod(mod, this.parent.getModHasConfigScreen(modId))) {
                 continue;
             }
 
@@ -199,7 +199,7 @@ public class ModListWidget extends ObjectSelectionList<ModListEntry> implements 
                         List<Mod> validChildren = ModSearch.search(this.parent, searchTerm, children);
                         for (Mod child : validChildren) {
                             //Hide child lib mods when the config is set to hide
-                            if (child.getBadges().contains(Mod.Badge.LIBRARY) && !ModMenuConfig.SHOW_LIBRARIES.getValue()) {
+                            if (ModMenuConfig.SHOW_LIBRARIES.getValue().hideMod(child, this.parent.getModHasConfigScreen(child.getId()))) {
                                 continue;
                             }
 

--- a/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/mod/ModSearch.java
@@ -48,7 +48,7 @@ public class ModSearch {
         String hasUpdate = I18n.get("modmenu.searchTerms.hasUpdate");
 
         // Libraries are currently hidden, ignore them entirely
-        if (mod.isHidden() || !ModMenuConfig.SHOW_LIBRARIES.getValue() && mod.getBadges().contains(Mod.Badge.LIBRARY)) {
+        if (mod.isHidden() || ModMenuConfig.SHOW_LIBRARIES.getValue().hideMod(mod, ModMenu.hasConfigScreen(mod.getId()))) {
             return 0;
         }
 

--- a/src/main/resources/assets/modmenu/lang/en_us.json
+++ b/src/main/resources/assets/modmenu/lang/en_us.json
@@ -118,6 +118,7 @@
   "option.modmenu.show_libraries": "Libraries",
   "option.modmenu.show_libraries.true": "Shown",
   "option.modmenu.show_libraries.false": "Hidden",
+  "option.modmenu.show_libraries.with_config": "With Config",
   "option.modmenu.hide_config_buttons": "Config Buttons",
   "option.modmenu.hide_config_buttons.true": "Hidden",
   "option.modmenu.hide_config_buttons.false": "Shown",


### PR DESCRIPTION
As the title, adds a setting to only hide libraries that aren't configurable and changes the default to it. Mostly for cases where library happens to change something a player might be able to change (which is a case with my Trinkets Updated for example)

<img width="1919" height="1007" alt="image" src="https://github.com/user-attachments/assets/58017127-03b0-486f-9f0b-0db42da14d09" />
